### PR TITLE
Add license information to the Maven POM file

### DIFF
--- a/fhir-model/build.gradle.kts
+++ b/fhir-model/build.gradle.kts
@@ -127,6 +127,18 @@ publishing {
             url = localRepo.asFile.toURI()
         }
     }
+    publications {
+        withType<MavenPublication> {
+            pom {
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+            }
+        }
+    }
 }
 val deleteRepoTask = tasks.register<Delete>("deleteLocalRepo") {
     description =


### PR DESCRIPTION
Adds a POM configuration with license details for Apache 2.0.

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
