### PR TITLE
Enable serialization round-trip tests as Android instrumented tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,13 @@ notation instead of scientific notation (e.g. 1000000000000000000 instead of 1E1
 serialization process normalizes these variations, resulting in potentially different JSON output.
 However, in all of these cases, semantic equivalence is maintained.
 
+These tests are set up to run on JVM and as Android instrumented tests. To run them locally:
+
+```shell
+./gradlew :fhir-model:jvmTest
+./gradlew :fhir-model:connectedAndroidTest
+```
+
 ## Publishing
 
 To create a maven repository from the project, run:

--- a/fhir-model/build.gradle.kts
+++ b/fhir-model/build.gradle.kts
@@ -99,6 +99,18 @@ kotlin {
                 implementation(libs.kotlinx.serialization.json)
             }
         }
+        val androidMain by getting
+        val androidInstrumentedTest by getting {
+            dependsOn(commonTest)
+            val projectRootPath = project.rootDir.absolutePath
+            resources.srcDir("$projectRootPath/third_party")
+            dependencies {
+                implementation(libs.androidx.test.espresso)
+                implementation(libs.androidx.test.junit)
+                implementation(libs.androidx.test.rules)
+                implementation(libs.androidx.test.runner)
+            }
+        }
         val jvmMain by getting
         val jvmTest by getting
         val jsMain by getting
@@ -111,6 +123,15 @@ android {
     compileSdk = libs.versions.android.compileSdk.get().toInt()
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["jvmArgs"] = "-Xmx4g"
+    }
+    sourceSets {
+        getByName("androidTest") {
+            // Make third party package available to Android instrumented tests
+            val projectRootPath = project.rootDir.absolutePath
+            assets.srcDir("$projectRootPath/third_party")
+        }
     }
 }
 

--- a/fhir-model/build.gradle.kts
+++ b/fhir-model/build.gradle.kts
@@ -102,8 +102,6 @@ kotlin {
         val androidMain by getting
         val androidInstrumentedTest by getting {
             dependsOn(commonTest)
-            val projectRootPath = project.rootDir.absolutePath
-            resources.srcDir("$projectRootPath/third_party")
             dependencies {
                 implementation(libs.androidx.test.espresso)
                 implementation(libs.androidx.test.junit)

--- a/fhir-model/src/androidInstrumentedTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.android.kt
+++ b/fhir-model/src/androidInstrumentedTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.android.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhir.model
+
+import android.content.res.AssetManager
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
+val assetManager: AssetManager = InstrumentationRegistry.getInstrumentation().context.assets
+
+actual fun forEachR4Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
+  InstrumentationRegistry.getInstrumentation()
+    .context
+    .assets
+    .list(r4ExamplePackage)!!
+    .filter { fileNameFilter(it) }
+    .forEach { fileName ->
+      assetManager.open("${r4ExamplePackage}${fileName}").use { it ->
+        val content = BufferedReader(InputStreamReader(it)).use { it.readText() }
+        block(content)
+      }
+    }
+}
+
+actual fun forEachR4BExample(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
+  InstrumentationRegistry.getInstrumentation()
+    .context
+    .assets
+    .list(r4bExamplePackage)!!
+    .filter { fileNameFilter(it) }
+    .forEach { fileName ->
+      assetManager.open("$r4bExamplePackage${fileName}").use { it ->
+        val content = BufferedReader(InputStreamReader(it)).use { it.readText() }
+        block(content)
+      }
+    }
+}
+
+actual fun forEachR5Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
+  InstrumentationRegistry.getInstrumentation()
+    .context
+    .assets
+    .list(r5ExamplePackage)!!
+    .filter { fileNameFilter(it) }
+    .forEach { fileName ->
+      assetManager.open("$r5ExamplePackage${fileName}").use { it ->
+        val content = BufferedReader(InputStreamReader(it)).use { it.readText() }
+        block(content)
+      }
+    }
+}

--- a/fhir-model/src/androidInstrumentedTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.android.kt
+++ b/fhir-model/src/androidInstrumentedTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.android.kt
@@ -23,44 +23,31 @@ import java.io.InputStreamReader
 
 val assetManager: AssetManager = InstrumentationRegistry.getInstrumentation().context.assets
 
-actual fun forEachR4Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
-  InstrumentationRegistry.getInstrumentation()
+private fun loadExamplesFromAssets(
+  examplePackage: String,
+  fileNameFilter: (String) -> Boolean,
+): Sequence<String> {
+  return InstrumentationRegistry.getInstrumentation()
     .context
     .assets
-    .list(r4ExamplePackage)!!
+    .list(examplePackage)!!
+    .asSequence()
     .filter { fileNameFilter(it) }
-    .forEach { fileName ->
-      assetManager.open("${r4ExamplePackage}${fileName}").use { it ->
-        val content = BufferedReader(InputStreamReader(it)).use { it.readText() }
-        block(content)
+    .map { fileName ->
+      assetManager.open("$examplePackage${fileName}").use { it ->
+        BufferedReader(InputStreamReader(it)).use { it.readText() }
       }
     }
 }
 
-actual fun forEachR4BExample(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
-  InstrumentationRegistry.getInstrumentation()
-    .context
-    .assets
-    .list(r4bExamplePackage)!!
-    .filter { fileNameFilter(it) }
-    .forEach { fileName ->
-      assetManager.open("$r4bExamplePackage${fileName}").use { it ->
-        val content = BufferedReader(InputStreamReader(it)).use { it.readText() }
-        block(content)
-      }
-    }
+actual fun loadR4Examples(fileNameFilter: (String) -> Boolean): Sequence<String> {
+  return loadExamplesFromAssets(r4ExamplePackage, fileNameFilter)
 }
 
-actual fun forEachR5Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
-  InstrumentationRegistry.getInstrumentation()
-    .context
-    .assets
-    .list(r5ExamplePackage)!!
-    .filter { fileNameFilter(it) }
-    .forEach { fileName ->
-      assetManager.open("$r5ExamplePackage${fileName}").use { it ->
-        val content = BufferedReader(InputStreamReader(it)).use { it.readText() }
-        block(content)
-      }
-    }
+actual fun loadR4BExamples(fileNameFilter: (String) -> Boolean): Sequence<String> {
+  return loadExamplesFromAssets(r4bExamplePackage, fileNameFilter)
+}
+
+actual fun loadR5Examples(fileNameFilter: (String) -> Boolean): Sequence<String> {
+  return loadExamplesFromAssets(r5ExamplePackage, fileNameFilter)
 }

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.kt
@@ -138,50 +138,50 @@ val exclusionListR5 =
 class SerializationRoundTripTest {
   @Test
   fun shouldMatchOriginalJsonAfterDeserializationAndSerializationInR4() {
-    forEachR4Example(
-      fileNameFilter = {
-        return@forEachR4Example (filterFileName(it) && !exclusionListR4.contains(it))
-      },
-      block = {
+    loadR4Examples(
+        fileNameFilter = {
+          return@loadR4Examples (filterFileName(it) && !exclusionListR4.contains(it))
+        }
+      )
+      .forEach {
         val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r4.Resource =
           json.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
         val reserializedString = json.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
-      },
-    )
+      }
   }
 
   @Test
   fun shouldMatchOriginalJsonAfterDeserializationAndSerializationInR4B() {
-    forEachR4BExample(
-      fileNameFilter = {
-        return@forEachR4BExample (filterFileName(it) && !exclusionListR4B.contains(it))
-      },
-      block = {
+    loadR4BExamples(
+        fileNameFilter = {
+          return@loadR4BExamples (filterFileName(it) && !exclusionListR4B.contains(it))
+        }
+      )
+      .forEach {
         val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r4b.Resource =
           json.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
         val reserializedString = json.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
-      },
-    )
+      }
   }
 
   @Test
   fun shouldMatchOriginalJsonAfterDeserializationAndSerializationInR5() {
-    forEachR5Example(
-      fileNameFilter = {
-        return@forEachR5Example (filterFileName(it) && !exclusionListR5.contains(it))
-      },
-      block = {
+    loadR5Examples(
+        fileNameFilter = {
+          return@loadR5Examples (filterFileName(it) && !exclusionListR5.contains(it))
+        }
+      )
+      .forEach {
         val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r5.Resource =
           json.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
         val reserializedString = json.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
-      },
-    )
+      }
   }
 
   companion object {
@@ -225,8 +225,8 @@ class SerializationRoundTripTest {
   }
 }
 
-expect fun forEachR4Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit)
+expect fun loadR4Examples(fileNameFilter: (String) -> Boolean): Sequence<String>
 
-expect fun forEachR4BExample(fileNameFilter: (String) -> Boolean, block: (String) -> Unit)
+expect fun loadR4BExamples(fileNameFilter: (String) -> Boolean): Sequence<String>
 
-expect fun forEachR5Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit)
+expect fun loadR5Examples(fileNameFilter: (String) -> Boolean): Sequence<String>

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.kt
@@ -16,11 +16,16 @@
 
 package com.google.fhir.model
 
-import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
+
+const val r4ExamplePackage = "hl7.fhir.r4.examples/package/"
+const val r4bExamplePackage = "hl7.fhir.r4b.examples/package/"
+const val r5ExamplePackage = "hl7.fhir.r5.examples/package/"
+
+val trailingZeroRegex = "\\.0+".toRegex()
 
 val exclusionListR4 =
   listOf(
@@ -63,7 +68,7 @@ val exclusionListR4B =
     "Observation-decimal.json",
   )
 
-val exclusionsListR5 =
+val exclusionListR5 =
   listOf(
     // Java heap space
     "Bundle-resources.json",
@@ -132,63 +137,51 @@ val exclusionsListR5 =
  */
 class SerializationRoundTripTest {
   @Test
-  fun `should match original json after deserialization and serialization in R4`() {
-    File("${System.getProperty("projectRootDir")}/third_party/hl7.fhir.r4.examples/package")
-      .listFiles()
-      ?.asSequence()
-      ?.filter { it.name.endsWith(".json") }
-      ?.filterNot {
-        it.name.startsWith('.') // filter out `.index.json` file
-      }
-      ?.filterNot { it.name == "package.json" }
-      ?.filterNot { exclusionListR4.contains(it.name) }
-      ?.forEach { file ->
-        val exampleJson = prettyPrintJson(file.readText())
+  fun shouldMatchOriginalJsonAfterDeserializationAndSerializationInR4() {
+    forEachR4Example(
+      fileNameFilter = {
+        return@forEachR4Example (filterFileName(it) && !exclusionListR4.contains(it))
+      },
+      block = {
+        val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r4.Resource =
-          Json.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
+          json.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
         val reserializedString = json.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
-      }
+      },
+    )
   }
 
   @Test
-  fun `should match original json after deserialization and serialization in R4B`() {
-    File("${System.getProperty("projectRootDir")}/third_party/hl7.fhir.r4b.examples/package")
-      .listFiles()
-      ?.asSequence()
-      ?.filter { it.name.endsWith(".json") }
-      ?.filterNot {
-        it.name.startsWith('.') // filter out `.index.json` file
-      }
-      ?.filterNot { it.name == "package.json" }
-      ?.filterNot { exclusionListR4B.contains(it.name) }
-      ?.forEach { file ->
-        val exampleJson = prettyPrintJson(file.readText())
+  fun shouldMatchOriginalJsonAfterDeserializationAndSerializationInR4B() {
+    forEachR4BExample(
+      fileNameFilter = {
+        return@forEachR4BExample (filterFileName(it) && !exclusionListR4B.contains(it))
+      },
+      block = {
+        val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r4b.Resource =
-          Json.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
+          json.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
         val reserializedString = json.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
-      }
+      },
+    )
   }
 
   @Test
-  fun `should match original json after deserialization and serialization in R5`() {
-    File("${System.getProperty("projectRootDir")}/third_party/hl7.fhir.r5.examples/package")
-      .listFiles()
-      ?.asSequence()
-      ?.filter { it.name.endsWith(".json") }
-      ?.filterNot {
-        it.name.startsWith('.') // filter out `.index.json` file
-      }
-      ?.filterNot { it.name == "package.json" }
-      ?.filterNot { exclusionsListR5.contains(it.name) }
-      ?.forEach { file ->
-        val exampleJson = prettyPrintJson(file.readText())
+  fun shouldMatchOriginalJsonAfterDeserializationAndSerializationInR5() {
+    forEachR5Example(
+      fileNameFilter = {
+        return@forEachR5Example (filterFileName(it) && !exclusionListR5.contains(it))
+      },
+      block = {
+        val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r5.Resource =
-          Json.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
+          json.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
         val reserializedString = json.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
-      }
+      },
+    )
   }
 
   companion object {
@@ -199,6 +192,13 @@ class SerializationRoundTripTest {
     }
 
     private val prettyPrintJson = Json { prettyPrint = true }
+
+    fun filterFileName(name: String): Boolean {
+      return name.endsWith(".json") &&
+        !name.startsWith('.') // filter out `.index.json` file
+        &&
+        name != "package.json"
+    }
 
     private fun prettyPrintJson(jsonString: String): String {
       val jsonElement =
@@ -221,6 +221,12 @@ class SerializationRoundTripTest {
       )
     }
 
-    private fun String.removeZerosAfterDecimalPoint(): String = replace("\\.[0]+".toRegex(), "")
+    private fun String.removeZerosAfterDecimalPoint(): String = replace(trailingZeroRegex, "")
   }
 }
+
+expect fun forEachR4Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit)
+
+expect fun forEachR4BExample(fileNameFilter: (String) -> Boolean, block: (String) -> Unit)
+
+expect fun forEachR5Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit)

--- a/fhir-model/src/jvmTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.jvm.kt
+++ b/fhir-model/src/jvmTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.jvm.kt
@@ -18,23 +18,25 @@ package com.google.fhir.model
 
 import java.io.File
 
-actual fun forEachR4Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
-  File("${System.getProperty("projectRootDir")}/third_party/${r4ExamplePackage}")
+private fun loadExamplesFromFileSystem(
+  directoryName: String,
+  fileNameFilter: (String) -> Boolean,
+): Sequence<String> {
+  return File("${System.getProperty("projectRootDir")}/third_party/${directoryName}")
     .listFiles()!!
+    .asSequence()
     .filter { fileNameFilter(it.name) }
-    .forEach { block(it.readText()) }
+    .map { it.readText() }
 }
 
-actual fun forEachR4BExample(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
-  File("${System.getProperty("projectRootDir")}/third_party/${r4bExamplePackage}")
-    .listFiles()!!
-    .filter { fileNameFilter(it.name) }
-    .forEach { block(it.readText()) }
+actual fun loadR4Examples(fileNameFilter: (String) -> Boolean): Sequence<String> {
+  return loadExamplesFromFileSystem(r4ExamplePackage, fileNameFilter)
 }
 
-actual fun forEachR5Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
-  File("${System.getProperty("projectRootDir")}/third_party/${r5ExamplePackage}")
-    .listFiles()!!
-    .filter { fileNameFilter(it.name) }
-    .forEach { block(it.readText()) }
+actual fun loadR4BExamples(fileNameFilter: (String) -> Boolean): Sequence<String> {
+  return loadExamplesFromFileSystem(r4bExamplePackage, fileNameFilter)
+}
+
+actual fun loadR5Examples(fileNameFilter: (String) -> Boolean): Sequence<String> {
+  return loadExamplesFromFileSystem(r5ExamplePackage, fileNameFilter)
 }

--- a/fhir-model/src/jvmTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.jvm.kt
+++ b/fhir-model/src/jvmTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.jvm.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhir.model
+
+import java.io.File
+
+actual fun forEachR4Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
+  File("${System.getProperty("projectRootDir")}/third_party/${r4ExamplePackage}")
+    .listFiles()!!
+    .filter { fileNameFilter(it.name) }
+    .forEach { block(it.readText()) }
+}
+
+actual fun forEachR4BExample(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
+  File("${System.getProperty("projectRootDir")}/third_party/${r4bExamplePackage}")
+    .listFiles()!!
+    .filter { fileNameFilter(it.name) }
+    .forEach { block(it.readText()) }
+}
+
+actual fun forEachR5Example(fileNameFilter: (String) -> Boolean, block: (String) -> Unit) {
+  File("${System.getProperty("projectRootDir")}/third_party/${r5ExamplePackage}")
+    .listFiles()!!
+    .filter { fileNameFilter(it.name) }
+    .forEach { block(it.readText()) }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
 android-gradle-plugin = "8.5.2"
+android-compileSdk = "35"
 android-minSdk = "24"
-android-compileSdk = "34"
+androidx-test-espresso = "3.5.1"
+androidx-test-junit = "1.2.1"
+androidx-test-rules = "1.6.1"
+androidx-test-runner = "1.6.2"
 kotlin = "2.1.0"
 kotlin-poet = "2.0.0"
 kotlinx-datetime = "0.6.2"
@@ -10,6 +14,10 @@ maven-publish = "0.29.0"
 spotless = "7.0.1"
 
 [libraries]
+androidx-test-espresso = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }
+androidx-test-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-junit" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-rules" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
@@ -20,5 +28,5 @@ android-library = { id = "com.android.library", version.ref = "android-gradle-pl
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
This PR does the following:

- Create common tests (under `commonTest` directory) to be run in all platforms - platform-specific tests need to specify how to load the JSON examples
- Refactor the jvm tests to use common tests
- Set up Android instrumented tests that depend on common tests with assets loaded from third_party directory
- Update `README.md`