### PR TITLE
Use open polymorphism instead of closed polymorphism

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,9 @@ This serves as a hint to the `kotlinx.serialization` library so it can dynamical
 correct FHIR resource type, or subclass, to instantiate based on the JSON content at runtime.
 
 However, during _serialization_, since the runtime type of the resource is already known, it is
-possible to call the `encodeToString` function without having to specify the type parameter. But
-this would be a mistake, since the `kotlinx.serialization` library would not include the
-`resourceType` property in the serialized result in such cases, generating malformed FHIR JSON.
+possible to call the `encodeToString` function without the type parameter. But this would be a
+mistake, since the `kotlinx.serialization` library would not include the `resourceType` property in
+the serialized result in such cases, generating malformed FHIR JSON.
 
 > **Note:** `encodeToString` function must be called with the type parameter `<Resource>`. Failing
 > to do so will result in malformed FHIR JSON.

--- a/README.md
+++ b/README.md
@@ -262,34 +262,9 @@ mentioned [earlier](#mapping-fhir-primitive-data-types-to-kotlin).
 
 ## User Guide
 
-### Running the codegen locally
-
-You can manually run the code generator (codegen) to inspect the generated code or, as an
-alternative to using the library as a dependency, copy the generated code into your project for
-direct use.
-
-Run the following command, replacing `<FHIR_VERSION>` with your desired FHIR version (`r4`, `r4b`,
-or `r5`):
-
-```bash
-./gradlew <FHIR_VERSION>
-```
-
-For example, to generate code for FHIR R4:
-
-```bash
-./gradlew r4
-```
-
-The generated code will be located in the `fhir-model/build/generated/<FHIR_VERSION>` subdirectory.
-
-> **Note:** The library is designed for use as a dependency. Directly copying generated code into
-> your project is generally discouraged as it can lead to maintenance issues and conflicts with
-> future updates.
-
 ### Using the Gradle plugin
 
-> **TODO:** add instructions on how to use the gradle plugin
+> **TODO:** add instructions on how to use the gradle plugin once it is published
 
 ### Adding the library to your project
 
@@ -368,14 +343,15 @@ fun main() {
 }
 ```
 
-### Serialization
+### Serialization and deserialization
 
-To use the [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) APIs for 
-serialization and deserialization of the generated FHIR resources, set up the `Json` object with the
-extension function provided for the specific FHIR version:
+To serialize and deserialize FHIR resources, first set up
+[kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization)'s `Json` object with the
+extension function `configure<FHIR_VERSION>()` provided by the Kotlin FHIR library for the specific
+FHIR version:
 
 ```kotlin
-import com.google.fhir.model.r4.configureR4
+import com.google.fhir.model.r4.configureR4  // or com.google.fhir.model.r4b.configureR4b or com.google.fhir.model.r5.configureR5
 import kotlinx.serialization.json.Json
 
 fun main() {
@@ -385,51 +361,108 @@ fun main() {
 }
 ```
 
-> **Note:** The `Json` object can only be configured to work with a specific FHIR version at time.
+> **Note:** The `Json` object can only be configured to work with a specific FHIR version at a time.
 > Use different `Json` objects for working with multiple FHIR versions.
 
 Once the `Json` object is correctly configured, it can be used to serialize and deserialize FHIR
-resources of the specified version. In the following example, we first serialize the previously
-created patient resource to a JSON string, and then deserialize it back into a new patient object:
+resources of the specific version. In the following example, we first serialize the previously
+created patient resource in FHIR R4 to a JSON string, and then deserialize it back into a new
+patient object:
 
 ```kotlin
 import com.google.fhir.model.r4.Patient
 import com.google.fhir.model.r4.Resource
-import com.google.fhir.model.r4.configureR4
-import kotlinx.serialization.json.Json
 
 fun main() {
-    val json = Json {
-        configureR4()  // or configureR4b() or configureR5()
-    }
+    val jsonString = json.encodeToString<Resource>(patient)  // Serialization
+    val reconstructedPatient = json.decodeFromString<Resource>(jsonString)  // Deserialization
     
-    val jsonString = json.encodeToString<Resource>(patient) // Serialization
-    val reconstructedPatient = json.decodeFromString<Resource>(jsonString) // Deserialization
-    
-    check(reconstructedPatient is Patient)  // True
+    check(reconstructedPatient is Patient)
 }
 ```
 
 #### Polymorphism
 
-In the example above, notice the type parameter `Resource` for the serialization and deserialization
-function calls `encodeToString` and `decodeFromString`. This is a critical detail.
+In the example above, notice the type parameter `<Resource>` in the serialization and
+deserialization function calls <code>encodeToString<b>\<Resource\></b></code> and
+<code>decodeFromString<b>\<Resource\></b></code>. This is a critical detail.
 
 To allow the `kotlinx.serialization` library to determine the resource type at runtime during
-_deserialization_, the Kotlin FHIR library marks the `resourceType` JSON property as a
-[JsonClassDiscriminator](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-class-discriminator/).
+_deserialization_, the Kotlin FHIR library uses the `resourceType` JSON property as the
+[JSON class discriminator](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#class-discriminator-for-polymorphism).
 This serves as a hint to the `kotlinx.serialization` library so it can dynamically select the
-correct FHIR resource type, or subclass, to instantiate based on the JSON content at runtime.
+correct FHIR resource type, or subclass, to instantiate based on the JSON content at runtime.[^5]
 
-However, during _serialization_, since the runtime type of the resource is already known, it is
-possible to call the `encodeToString` function without the type parameter. But this would be a
-mistake, since the `kotlinx.serialization` library would not include the `resourceType` property in
-the serialized result in such cases, generating malformed FHIR JSON.
+[^5]: If the resource type is known at compile time, it is safe to use a more specific type 
+parameter while deserializing, such as `decodeFromString<Patient>(jsonString)`, provided that the
+`Json` object is configured with `ignoreUnknownKeys = true`. The `ignoreUnknownKeys` option is
+critical because with the more specific type parameter the `kotlinx.serialization` library knows the
+specific type to instantiate and no longer uses the `resourceType` JSON property as a
+[JSON class discriminator](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/json.md#class-discriminator-for-polymorphism)
+as is the case when the type parameter `<Resource>` is used. Instead, it will attempt to map the
+`resourceType` JSON property to a regular field in the specified class (e.g., `Patient`). As a
+result, without `ignoreUnknownKeys = true` an error will occur since the target class does not have
+a corresponding field for the `resourceType` property.
 
-> **Note:** `encodeToString` function must be called with the type parameter `<Resource>`. Failing
-> to do so will result in malformed FHIR JSON.
+However, during _serialization_, it is possible to call the `encodeToString` function without the
+type parameter, or with the type parameter of the specific resource type if it is known at compile
+time, e.g. `encodeToString<Patient>`. But this would be a mistake, since the `kotlinx.serialization`
+library would not treat the serialization as polymorphic in these cases. As a result, it would not
+include the `resourceType` property in the serialized result, generating malformed FHIR JSON.
+Therefore, when serializing FHIR resources, always make sure to include the `<Resource>` type
+parameter like this: <code>encodeToString<b>\<Resource\></b></code>.
 
-## Testing
+```kotlin
+import com.google.fhir.model.r4.Resource
+
+fun main() {
+    // ✅ DO: 
+    val validPatient = json.encodeToString<Resource>(patient)
+    
+    // ⛔ DON'T:
+    // val invalidPatient = json.encodeToString<Patient>(patient)
+}
+```
+
+> ⚠️ **Warning:** `encodeToString` function must be called with the type parameter `<Resource>`.
+> Failing to do so will result in malformed FHIR JSON.
+
+To summarize, we recommend always using the type parameter `<Resource>` when calling
+`encodeToString` and `decodeFromString` to serialize and deserialize FHIR resources:
+<code>encodeToString<b>\<Resource\></b></code> and <code>decodeFromString<b>\<Resource\></b></code>.
+To learn more about polymorphism in serialization in Kotlin, see the
+[Kotlin Serialization Guide](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md).
+
+## Developer Guide
+
+This section is for developers who want to contribute to the library.
+
+### Running the codegen locally
+
+You can manually run the code generator (codegen) to inspect the generated code or, as an
+alternative to using the library as a dependency, copy the generated code into your project for
+direct use.
+
+Run the following command, replacing `<FHIR_VERSION>` with your desired FHIR version (`r4`, `r4b`,
+or `r5`):
+
+```bash
+./gradlew <FHIR_VERSION>
+```
+
+For example, to generate code for FHIR R4:
+
+```bash
+./gradlew r4
+```
+
+The generated code will be located in the `fhir-model/build/generated/<FHIR_VERSION>` subdirectory.
+
+> **Note:** The library is designed for use as a dependency. Directly copying generated code into
+> your project is generally discouraged as it can lead to maintenance issues and conflicts with
+> future updates.
+
+### Testing
 
 The library includes comprehensive **serialization round-trip tests** for examples published in the
 following packages:
@@ -443,10 +476,10 @@ following steps:
 
 1. Deserialization: The JSON is deserialized into the corresponding generated Kotlin resource class.
 1. Serialization: The Kotlin object is then serialized back into JSON format.
-1. Verification: The newly generated JSON is compared, character by character[^5], to the original
+1. Verification: The newly generated JSON is compared, character by character[^6], to the original
    JSON to ensure complete fidelity.
 
-[^5]: There are several exceptions. The FHIR specification allows for some variability in data
+[^6]: There are several exceptions. The FHIR specification allows for some variability in data
 representation, which may lead to differences between the original and newly serialized JSON. For
 example, additional trailing zeros in decimals and times, non-standard JSON property ordering, the
 use of `+00:00` instead of `Z` for zero UTC offset, and large numbers represented in standard
@@ -461,16 +494,24 @@ These tests are set up to run on JVM and as Android instrumented tests. To run t
 ./gradlew :fhir-model:connectedAndroidTest
 ```
 
-## Publishing
+### Publishing
 
-To create a maven repository from the project, run:
+To create a maven repository from the generated FHIR model, run:
 
-`./gradlew :fhir-model:publish`
+```
+./gradlew :fhir-model:publish
+```
 
-This will create a maven repository in the `fhir-model/build/repo` directory.
+This will create a maven repository in the `fhir-model/build/repo` directory with artifacts for all
+supported platforms.
 
-There is also a `zipRepo` task that will zip the repository into the `fhir-model/build/repoZip`
-directory.
+To zip the repository, run:
+
+```
+./gradlew :fhir-model:zipRepo
+```
+
+This will generate a `.zip` file in the `fhir-model/build/repoZip` directory.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ fun main() {
 > Use different `Json` objects for working with multiple FHIR versions.
 
 Once the `Json` object is correctly configured, it can be used to serialize and deserialize FHIR
-resources of the configured version. In the following example, we first serialize the previously
+resources of the specified version. In the following example, we first serialize the previously
 created patient resource to a JSON string, and then deserialize it back into a new patient object:
 
 ```kotlin
@@ -416,15 +416,15 @@ In the example above, notice the type parameter `Resource` for the serialization
 function calls `encodeToString` and `decodeFromString`. This is a critical detail.
 
 To allow the `kotlinx.serialization` library to determine the resource type at runtime during
-deserialization, the Kotlin FHIR library marks the `resourceType` JSON property as a
+_deserialization_, the Kotlin FHIR library marks the `resourceType` JSON property as a
 [JsonClassDiscriminator](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-class-discriminator/).
 This serves as a hint to the `kotlinx.serialization` library so it can dynamically select the
 correct FHIR resource type, or subclass, to instantiate based on the JSON content at runtime.
 
-However, during serialization, since the runtime type of the resource is already known, it is
-possible to call the `encodeToString` function without having to specify the type parameter. In such
-cases, the `kotlinx.serialization` library will not include the `resourceType` property in the
-serialized result, generating malformed FHIR JSON.
+However, during _serialization_, since the runtime type of the resource is already known, it is
+possible to call the `encodeToString` function without having to specify the type parameter. But
+this would be a mistake, since the `kotlinx.serialization` library would not include the
+`resourceType` property in the serialized result in such cases, generating malformed FHIR JSON.
 
 > **Note:** `encodeToString` function must be called with the type parameter `<Resource>`. Failing
 > to do so will result in malformed FHIR JSON.

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/com/google/fhir/codegen/ModelTypeSpecGenerator.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/com/google/fhir/codegen/ModelTypeSpecGenerator.kt
@@ -39,7 +39,6 @@ import com.squareup.kotlinpoet.asTypeName
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonClassDiscriminator
 import org.gradle.configurationcache.extensions.capitalized
 
 /** Generates a [TypeSpec] for a model class. */
@@ -57,14 +56,19 @@ object ModelTypeSpecGenerator {
         .apply {
           val structureDefinitionName = structureDefinition.name
 
-          if (structureDefinitionName == "Resource" || structureDefinitionName == "DomainResource") {
-            // We use open polymorphism to allow for runtime decision on which concrete class to instantiate
-            // Instead of sealing the `Resource` class, we keep it abstract.
+          if (
+            structureDefinitionName == "Resource" || structureDefinitionName == "DomainResource"
+          ) {
+            // We use open polymorphism to allow for runtime decision on which concrete class to
+            // instantiate. So instead of sealing the `Resource` class and `DomainResource` class,
+            // we keep them abstract.
+            // See
+            // https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#open-polymorphism
             addModifiers(KModifier.ABSTRACT)
           } else if (structureDefinition.abstract) {
-            // All abstract structure definitions should be sealed (and therefore abstract) classes,
-            // except for Element which is concrete but open to be used for fields prefixed with
-            // '_'.
+            // All other abstract structure definitions should be sealed (and therefore abstract)
+            // classes, except for Element which is concrete but open to be used for fields prefixed
+            // with '_'.
             if (structureDefinition.name == "Element") {
               addModifiers(KModifier.OPEN)
             } else {

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/com/google/fhir/codegen/MoreJsonBuilderFileSpecGenerator.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/com/google/fhir/codegen/MoreJsonBuilderFileSpecGenerator.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.fhir.codegen
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.PropertySpec
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
+import kotlinx.serialization.modules.SerializersModule
+
+/**
+ * Generates a [FileSpec] with utilities for configuring the [Json] object to serialize and
+ * deserialize FHIR resources in this package.
+ *
+ * The generated file includes an extension function for [JsonBuilder]. It configures the [Json]
+ * object by registering polymorphic types for FHIR resource hierarchies and setting appropriate
+ * class discriminators (e.g., "resourceType").
+ */
+object MoreJsonBuilderFileSpecGenerator {
+  fun generate(packageName: String, baseClass: ClassName, subclasses: List<ClassName>): FileSpec {
+    val fhirVersion = packageName.substringAfterLast('.').replaceFirstChar { it.uppercase() }
+    val funName = "configure${fhirVersion}"
+    val serializersModuleName = "serializersModule${fhirVersion}"
+    return FileSpec.builder(packageName, "MoreJsonBuilder")
+      .addFunction(
+        FunSpec.builder(funName)
+          .receiver(JsonBuilder::class)
+          .addStatement("classDiscriminator = \"resourceType\"")
+          .addStatement("serializersModule = $serializersModuleName")
+          .build()
+      )
+      .addProperty(
+        PropertySpec.builder(serializersModuleName, SerializersModule::class)
+          .addModifiers(KModifier.PRIVATE)
+          .initializer(
+            CodeBlock.builder()
+              .addStatement("%T {", SerializersModule::class)
+              .indent()
+              .apply {
+                subclasses.forEach {
+                  addStatement(
+                    "polymorphic(%T::class, %T::class, %T.serializer())",
+                    baseClass,
+                    it,
+                    it,
+                  )
+                }
+              }
+              .unindent()
+              .addStatement("}")
+              .build()
+          )
+          .build()
+      )
+      .build()
+  }
+}

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/com/google/fhir/codegen/primitives/FhirDateFileSpecGenerator.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/com/google/fhir/codegen/primitives/FhirDateFileSpecGenerator.kt
@@ -25,27 +25,22 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import kotlinx.datetime.LocalDate
-import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.UtcOffset
 
 /**
- * Generates a [FileSpec] for `FhirDateTime.kt` containing a sealed interface `FhirDateTime` which
- * is the implementation of the FHIR DateTime primitive type.
+ * Generates a [FileSpec] for `FhirDate.kt` containing a sealed interface `FhirDate` which is the
+ * implementation of the FHIR Date primitive type.
  *
- * In particular, this class handles partial date times.
+ * In particular, this class handles partial dates.
  * - **Year:** Only the year (e.g. `2025`)
  * - **Year and Month:** The year and the month (e.g. `2025-01`)
  * - **Date:** The date part (e.g. `2025-01-08`)
- * - **Date and Time:** The date and time parts with timezone offset (e.g. `2025-01-08T11:49:01Z`)
- *   conforming to [IS8601](https://www.iso.org/iso-8601-date-and-time-format.html).
  *
- * See e.g. [dateTime in R4](https://hl7.org/fhir/R4/datatypes.html#dateTime)
+ * See e.g. [date in R4](https://hl7.org/fhir/R4/datatypes.html#date)
  */
-object FhirDateTimeTypeGenerator {
+object FhirDateFileSpecGenerator {
   fun generate(packageName: String): FileSpec {
-    val sealedInterfaceClassName = ClassName(packageName, "FhirDateTime")
+    val sealedInterfaceClassName = ClassName(packageName, "FhirDate")
     return FileSpec.builder(sealedInterfaceClassName)
-      .addImport("kotlinx.datetime", "LocalDateTime", "format") // Import extension function
       .addType(
         TypeSpec.interfaceBuilder(sealedInterfaceClassName)
           .addModifiers(KModifier.SEALED)
@@ -105,42 +100,6 @@ object FhirDateTimeTypeGenerator {
                 )
                 .build()
             )
-            addType(
-              TypeSpec.classBuilder("DateTime")
-                .addSuperinterface(sealedInterfaceClassName)
-                .primaryConstructor(
-                  FunSpec.constructorBuilder()
-                    .addParameter("dateTime", LocalDateTime::class)
-                    .addParameter("utcOffset", UtcOffset::class)
-                    .build()
-                )
-                .addProperty(
-                  PropertySpec.builder("dateTime", LocalDateTime::class)
-                    .initializer("dateTime")
-                    .build()
-                )
-                .addProperty(
-                  PropertySpec.builder("utcOffset", UtcOffset::class)
-                    .initializer("utcOffset")
-                    .build()
-                )
-                .addFunction(
-                  FunSpec.builder("toString")
-                    .addModifiers(KModifier.OVERRIDE)
-                    .returns(String::class)
-                    // Use
-                    // [ISO
-                    // format](https://kotlinlang.org/api/kotlinx-datetime/kotlinx-datetime/kotlinx.datetime/-local-date-time/-formats/-i-s-o.html)
-                    // to make sure seconds are always included.
-                    .addCode(
-                      "return dateTime.format(%T.%N) + utcOffset.toString()",
-                      ClassName("kotlinx.datetime", "LocalDateTime").nestedClass("Formats"),
-                      "ISO",
-                    )
-                    .build()
-                )
-                .build()
-            )
             addFunction(
               FunSpec.builder("toString")
                 .addModifiers(KModifier.OVERRIDE)
@@ -164,9 +123,6 @@ object FhirDateTimeTypeGenerator {
                                     return YearMonth(parts[0].toInt(), parts[1].toInt())
                                 } else if (string.matches(Regex("\\d{4}-\\d{2}-\\d{2}"))) {
                                     return Date(LocalDate.parse(string))
-                                } else if (string.matches(Regex("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|([+\\-])\\d{2}:\\d{2})"))) {
-                                    val groups = Regex("(?<datetime>\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?)(?<utcoffset>Z|([+\\-])\\d{2}:\\d{2})").find(string)!!.groups
-                                    return DateTime(LocalDateTime.parse(groups["datetime"]!!.value), UtcOffset.parse(groups["utcoffset"]!!.value))
                                 }
                                 error("Invalid string value: ${'$'}string")
                                 """

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/SerializationRoundTripTest.kt
@@ -16,6 +16,9 @@
 
 package com.google.fhir.model
 
+import com.google.fhir.model.r4.configureR4
+import com.google.fhir.model.r4b.configureR4b
+import com.google.fhir.model.r5.configureR5
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.json.Json
@@ -146,8 +149,8 @@ class SerializationRoundTripTest {
       .forEach {
         val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r4.Resource =
-          json.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
-        val reserializedString = json.encodeToString(domainResource)
+          jsonR4.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
+        val reserializedString = jsonR4.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
       }
   }
@@ -162,8 +165,8 @@ class SerializationRoundTripTest {
       .forEach {
         val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r4b.Resource =
-          json.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
-        val reserializedString = json.encodeToString(domainResource)
+          jsonR4B.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
+        val reserializedString = jsonR4B.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
       }
   }
@@ -178,17 +181,26 @@ class SerializationRoundTripTest {
       .forEach {
         val exampleJson = prettyPrintJson(it)
         val domainResource: com.google.fhir.model.r5.Resource =
-          json.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
-        val reserializedString = json.encodeToString(domainResource)
+          jsonR5.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
+        val reserializedString = jsonR5.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
       }
   }
 
   companion object {
-    private val json = Json {
-      ignoreUnknownKeys = true
-      explicitNulls = false
+    private val jsonR4 = Json {
       prettyPrint = true
+      configureR4()
+    }
+
+    private val jsonR4B = Json {
+      prettyPrint = true
+      configureR4b()
+    }
+
+    private val jsonR5 = Json {
+      prettyPrint = true
+      configureR5()
     }
 
     private val prettyPrintJson = Json { prettyPrint = true }
@@ -216,8 +228,8 @@ class SerializationRoundTripTest {
       // Some resources have non-standard JSON property ordering, so we sort the JSON
       // properties by the key before comparing them.
       assertEquals(
-        json.parseToJsonElement(expected).jsonObject.entries.sortedBy { it.key },
-        json.parseToJsonElement(actual).jsonObject.entries.sortedBy { it.key },
+        prettyPrintJson.parseToJsonElement(expected).jsonObject.entries.sortedBy { it.key },
+        prettyPrintJson.parseToJsonElement(actual).jsonObject.entries.sortedBy { it.key },
       )
     }
 


### PR DESCRIPTION
Fixes #17

This PR switches serialization from using [closed polymorphism](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#closed-polymorphism) to [open polymorphism](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/polymorphism.md#open-polymorphism). This circumvents the problem of recursive serializer intiialization due to complex class hierarchies in FHIR.

This requires users of the library to call a function `configureR[4|4b|5]` to set up the `Json` object to be used for serialization of FHIR resources of a particular version.

Additionally, this PR does the following:

- Update tests
- Add documentation on how to use the library with open polymorphism
- Reorganize documentation with a new "developer guide" section
- Rename a number of files to reflect their true purposes (e.g. generating `FileSpec` instead of `TypeSpec`)

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
