### PR TITLE
Upgrade Gradle, AGP, Kotlin, and kotlinx serialization versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx8192M"
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.parallel=true
 #Kotlin
 kotlin.code.style=official
 kotlin.js.compiler=ir
@@ -10,3 +11,4 @@ kotlin.mpp.enableCInteropCommonization=true
 #Android
 android.useAndroidX=true
 android.nonTransitiveRClass=true
+android.enableJetifier=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
-android-gradle-plugin = "8.5.2"
+android-gradle-plugin = "8.10.0"
 android-compileSdk = "35"
 android-minSdk = "24"
 androidx-test-espresso = "3.5.1"
 androidx-test-junit = "1.2.1"
 androidx-test-rules = "1.6.1"
 androidx-test-runner = "1.6.2"
-kotlin = "2.1.0"
+kotlin = "2.1.21"
 kotlin-poet = "2.0.0"
 kotlinx-datetime = "0.6.2"
-kotlinx-serialization-json = "1.8.0-RC"
+kotlinx-serialization-json = "1.8.1"
 maven-publish = "0.29.0"
 spotless = "7.0.1"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade Gradle from 8.7 to 8.14.1
- Upgrade AGP from 8.5.2 to 8.10.0
- Upgrade Kotlin from 2.1.0 to 2.1.21
- Upgrade kotlinx serialization library from 1.8.0-RC to 1.8.1
- Enable Gradle parallel build
- Disable Jetifier

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
