### PR TITLE
Expose kotlinx-datetime library as api

### DIFF
--- a/fhir-model/build.gradle.kts
+++ b/fhir-model/build.gradle.kts
@@ -113,7 +113,7 @@ kotlin {
             // task above.
             kotlin.setSrcDirs(listOf(file("src/commonMain/kotlin")))
             dependencies {
-                implementation(libs.kotlinx.datetime)
+                api(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.serialization.json)
             }
         }


### PR DESCRIPTION
Fixes #38 

The kotlinx-datetime library provides data classes used in the generated data model. Therefore it should be exposed as an API to be added to the classpath for any library users.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
