### PR TITLE
Redesign the JSON serialization API

### DIFF
--- a/fhir-model/src/commonMain/kotlin/com/google/fhir/model/r4/FhirR4Json.kt
+++ b/fhir-model/src/commonMain/kotlin/com/google/fhir/model/r4/FhirR4Json.kt
@@ -14,24 +14,30 @@
  * limitations under the License.
  */
 
-package com.google.fhir.model.r4b
+package com.google.fhir.model.r4
 
+import kotlin.String
+import kotlin.Unit
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
 
-public fun JsonBuilder.configureR4b() {
-  classDiscriminator = "resourceType"
-  serializersModule = serializersModuleR4b
+public class FhirR4Json(`init`: JsonBuilder.() -> Unit = {}) {
+  private val json: Json = Json {
+    prettyPrint = true
+    classDiscriminator = "resourceType"
+    serializersModule = serializersModuleR4
+    init()
+  }
+
+  public fun encodeToString(resource: Resource): String = json.encodeToString(resource)
+
+  public fun decodeFromString(string: String): Resource = json.decodeFromString<Resource>(string)
 }
 
-private val serializersModuleR4b: SerializersModule = SerializersModule {
+private val serializersModuleR4: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Account::class, Account.serializer())
   polymorphic(Resource::class, ActivityDefinition::class, ActivityDefinition.serializer())
-  polymorphic(
-    Resource::class,
-    AdministrableProductDefinition::class,
-    AdministrableProductDefinition.serializer(),
-  )
   polymorphic(Resource::class, AdverseEvent::class, AdverseEvent.serializer())
   polymorphic(Resource::class, AllergyIntolerance::class, AllergyIntolerance.serializer())
   polymorphic(Resource::class, Appointment::class, Appointment.serializer())
@@ -52,11 +58,9 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, CatalogEntry::class, CatalogEntry.serializer())
   polymorphic(Resource::class, ChargeItem::class, ChargeItem.serializer())
   polymorphic(Resource::class, ChargeItemDefinition::class, ChargeItemDefinition.serializer())
-  polymorphic(Resource::class, Citation::class, Citation.serializer())
   polymorphic(Resource::class, Claim::class, Claim.serializer())
   polymorphic(Resource::class, ClaimResponse::class, ClaimResponse.serializer())
   polymorphic(Resource::class, ClinicalImpression::class, ClinicalImpression.serializer())
-  polymorphic(Resource::class, ClinicalUseDefinition::class, ClinicalUseDefinition.serializer())
   polymorphic(Resource::class, CodeSystem::class, CodeSystem.serializer())
   polymorphic(Resource::class, Communication::class, Communication.serializer())
   polymorphic(Resource::class, CommunicationRequest::class, CommunicationRequest.serializer())
@@ -86,6 +90,7 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, DiagnosticReport::class, DiagnosticReport.serializer())
   polymorphic(Resource::class, DocumentManifest::class, DocumentManifest.serializer())
   polymorphic(Resource::class, DocumentReference::class, DocumentReference.serializer())
+  polymorphic(Resource::class, EffectEvidenceSynthesis::class, EffectEvidenceSynthesis.serializer())
   polymorphic(Resource::class, Encounter::class, Encounter.serializer())
   polymorphic(Resource::class, Endpoint::class, Endpoint.serializer())
   polymorphic(Resource::class, EnrollmentRequest::class, EnrollmentRequest.serializer())
@@ -93,7 +98,6 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, EpisodeOfCare::class, EpisodeOfCare.serializer())
   polymorphic(Resource::class, EventDefinition::class, EventDefinition.serializer())
   polymorphic(Resource::class, Evidence::class, Evidence.serializer())
-  polymorphic(Resource::class, EvidenceReport::class, EvidenceReport.serializer())
   polymorphic(Resource::class, EvidenceVariable::class, EvidenceVariable.serializer())
   polymorphic(Resource::class, ExampleScenario::class, ExampleScenario.serializer())
   polymorphic(Resource::class, ExplanationOfBenefit::class, ExplanationOfBenefit.serializer())
@@ -113,18 +117,12 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
     ImmunizationRecommendation.serializer(),
   )
   polymorphic(Resource::class, ImplementationGuide::class, ImplementationGuide.serializer())
-  polymorphic(Resource::class, Ingredient::class, Ingredient.serializer())
   polymorphic(Resource::class, InsurancePlan::class, InsurancePlan.serializer())
   polymorphic(Resource::class, Invoice::class, Invoice.serializer())
   polymorphic(Resource::class, Library::class, Library.serializer())
   polymorphic(Resource::class, Linkage::class, Linkage.serializer())
   polymorphic(Resource::class, List::class, List.serializer())
   polymorphic(Resource::class, Location::class, Location.serializer())
-  polymorphic(
-    Resource::class,
-    ManufacturedItemDefinition::class,
-    ManufacturedItemDefinition.serializer(),
-  )
   polymorphic(Resource::class, Measure::class, Measure.serializer())
   polymorphic(Resource::class, MeasureReport::class, MeasureReport.serializer())
   polymorphic(Resource::class, Media::class, Media.serializer())
@@ -138,28 +136,63 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, MedicationKnowledge::class, MedicationKnowledge.serializer())
   polymorphic(Resource::class, MedicationRequest::class, MedicationRequest.serializer())
   polymorphic(Resource::class, MedicationStatement::class, MedicationStatement.serializer())
+  polymorphic(Resource::class, MedicinalProduct::class, MedicinalProduct.serializer())
   polymorphic(
     Resource::class,
-    MedicinalProductDefinition::class,
-    MedicinalProductDefinition.serializer(),
+    MedicinalProductAuthorization::class,
+    MedicinalProductAuthorization.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductContraindication::class,
+    MedicinalProductContraindication.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductIndication::class,
+    MedicinalProductIndication.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductIngredient::class,
+    MedicinalProductIngredient.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductInteraction::class,
+    MedicinalProductInteraction.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductManufactured::class,
+    MedicinalProductManufactured.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductPackaged::class,
+    MedicinalProductPackaged.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductPharmaceutical::class,
+    MedicinalProductPharmaceutical.serializer(),
+  )
+  polymorphic(
+    Resource::class,
+    MedicinalProductUndesirableEffect::class,
+    MedicinalProductUndesirableEffect.serializer(),
   )
   polymorphic(Resource::class, MessageDefinition::class, MessageDefinition.serializer())
   polymorphic(Resource::class, MessageHeader::class, MessageHeader.serializer())
   polymorphic(Resource::class, MolecularSequence::class, MolecularSequence.serializer())
   polymorphic(Resource::class, NamingSystem::class, NamingSystem.serializer())
   polymorphic(Resource::class, NutritionOrder::class, NutritionOrder.serializer())
-  polymorphic(Resource::class, NutritionProduct::class, NutritionProduct.serializer())
   polymorphic(Resource::class, Observation::class, Observation.serializer())
   polymorphic(Resource::class, ObservationDefinition::class, ObservationDefinition.serializer())
   polymorphic(Resource::class, OperationDefinition::class, OperationDefinition.serializer())
   polymorphic(Resource::class, OperationOutcome::class, OperationOutcome.serializer())
   polymorphic(Resource::class, Organization::class, Organization.serializer())
   polymorphic(Resource::class, OrganizationAffiliation::class, OrganizationAffiliation.serializer())
-  polymorphic(
-    Resource::class,
-    PackagedProductDefinition::class,
-    PackagedProductDefinition.serializer(),
-  )
   polymorphic(Resource::class, Parameters::class, Parameters.serializer())
   polymorphic(Resource::class, Patient::class, Patient.serializer())
   polymorphic(Resource::class, PaymentNotice::class, PaymentNotice.serializer())
@@ -172,7 +205,6 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Provenance::class, Provenance.serializer())
   polymorphic(Resource::class, Questionnaire::class, Questionnaire.serializer())
   polymorphic(Resource::class, QuestionnaireResponse::class, QuestionnaireResponse.serializer())
-  polymorphic(Resource::class, RegulatedAuthorization::class, RegulatedAuthorization.serializer())
   polymorphic(Resource::class, RelatedPerson::class, RelatedPerson.serializer())
   polymorphic(Resource::class, RequestGroup::class, RequestGroup.serializer())
   polymorphic(Resource::class, ResearchDefinition::class, ResearchDefinition.serializer())
@@ -184,6 +216,7 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, ResearchStudy::class, ResearchStudy.serializer())
   polymorphic(Resource::class, ResearchSubject::class, ResearchSubject.serializer())
   polymorphic(Resource::class, RiskAssessment::class, RiskAssessment.serializer())
+  polymorphic(Resource::class, RiskEvidenceSynthesis::class, RiskEvidenceSynthesis.serializer())
   polymorphic(Resource::class, Schedule::class, Schedule.serializer())
   polymorphic(Resource::class, SearchParameter::class, SearchParameter.serializer())
   polymorphic(Resource::class, ServiceRequest::class, ServiceRequest.serializer())
@@ -193,10 +226,17 @@ private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, StructureDefinition::class, StructureDefinition.serializer())
   polymorphic(Resource::class, StructureMap::class, StructureMap.serializer())
   polymorphic(Resource::class, Subscription::class, Subscription.serializer())
-  polymorphic(Resource::class, SubscriptionStatus::class, SubscriptionStatus.serializer())
-  polymorphic(Resource::class, SubscriptionTopic::class, SubscriptionTopic.serializer())
   polymorphic(Resource::class, Substance::class, Substance.serializer())
-  polymorphic(Resource::class, SubstanceDefinition::class, SubstanceDefinition.serializer())
+  polymorphic(Resource::class, SubstanceNucleicAcid::class, SubstanceNucleicAcid.serializer())
+  polymorphic(Resource::class, SubstancePolymer::class, SubstancePolymer.serializer())
+  polymorphic(Resource::class, SubstanceProtein::class, SubstanceProtein.serializer())
+  polymorphic(
+    Resource::class,
+    SubstanceReferenceInformation::class,
+    SubstanceReferenceInformation.serializer(),
+  )
+  polymorphic(Resource::class, SubstanceSourceMaterial::class, SubstanceSourceMaterial.serializer())
+  polymorphic(Resource::class, SubstanceSpecification::class, SubstanceSpecification.serializer())
   polymorphic(Resource::class, SupplyDelivery::class, SupplyDelivery.serializer())
   polymorphic(Resource::class, SupplyRequest::class, SupplyRequest.serializer())
   polymorphic(Resource::class, Task::class, Task.serializer())

--- a/fhir-model/src/commonMain/kotlin/com/google/fhir/model/r4b/FhirR4bJson.kt
+++ b/fhir-model/src/commonMain/kotlin/com/google/fhir/model/r4b/FhirR4bJson.kt
@@ -14,20 +14,30 @@
  * limitations under the License.
  */
 
-package com.google.fhir.model.r5
+package com.google.fhir.model.r4b
 
+import kotlin.String
+import kotlin.Unit
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
 
-public fun JsonBuilder.configureR5() {
-  classDiscriminator = "resourceType"
-  serializersModule = serializersModuleR5
+public class FhirR4bJson(`init`: JsonBuilder.() -> Unit = {}) {
+  private val json: Json = Json {
+    prettyPrint = true
+    classDiscriminator = "resourceType"
+    serializersModule = serializersModuleR4b
+    init()
+  }
+
+  public fun encodeToString(resource: Resource): String = json.encodeToString(resource)
+
+  public fun decodeFromString(string: String): Resource = json.decodeFromString<Resource>(string)
 }
 
-private val serializersModuleR5: SerializersModule = SerializersModule {
+private val serializersModuleR4b: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Account::class, Account.serializer())
   polymorphic(Resource::class, ActivityDefinition::class, ActivityDefinition.serializer())
-  polymorphic(Resource::class, ActorDefinition::class, ActorDefinition.serializer())
   polymorphic(
     Resource::class,
     AdministrableProductDefinition::class,
@@ -37,7 +47,6 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, AllergyIntolerance::class, AllergyIntolerance.serializer())
   polymorphic(Resource::class, Appointment::class, Appointment.serializer())
   polymorphic(Resource::class, AppointmentResponse::class, AppointmentResponse.serializer())
-  polymorphic(Resource::class, ArtifactAssessment::class, ArtifactAssessment.serializer())
   polymorphic(Resource::class, AuditEvent::class, AuditEvent.serializer())
   polymorphic(Resource::class, Basic::class, Basic.serializer())
   polymorphic(Resource::class, Binary::class, Binary.serializer())
@@ -46,16 +55,12 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
     BiologicallyDerivedProduct::class,
     BiologicallyDerivedProduct.serializer(),
   )
-  polymorphic(
-    Resource::class,
-    BiologicallyDerivedProductDispense::class,
-    BiologicallyDerivedProductDispense.serializer(),
-  )
   polymorphic(Resource::class, BodyStructure::class, BodyStructure.serializer())
   polymorphic(Resource::class, Bundle::class, Bundle.serializer())
   polymorphic(Resource::class, CapabilityStatement::class, CapabilityStatement.serializer())
   polymorphic(Resource::class, CarePlan::class, CarePlan.serializer())
   polymorphic(Resource::class, CareTeam::class, CareTeam.serializer())
+  polymorphic(Resource::class, CatalogEntry::class, CatalogEntry.serializer())
   polymorphic(Resource::class, ChargeItem::class, ChargeItem.serializer())
   polymorphic(Resource::class, ChargeItemDefinition::class, ChargeItemDefinition.serializer())
   polymorphic(Resource::class, Citation::class, Citation.serializer())
@@ -70,7 +75,6 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Composition::class, Composition.serializer())
   polymorphic(Resource::class, ConceptMap::class, ConceptMap.serializer())
   polymorphic(Resource::class, Condition::class, Condition.serializer())
-  polymorphic(Resource::class, ConditionDefinition::class, ConditionDefinition.serializer())
   polymorphic(Resource::class, Consent::class, Consent.serializer())
   polymorphic(Resource::class, Contract::class, Contract.serializer())
   polymorphic(Resource::class, Coverage::class, Coverage.serializer())
@@ -86,16 +90,14 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   )
   polymorphic(Resource::class, DetectedIssue::class, DetectedIssue.serializer())
   polymorphic(Resource::class, Device::class, Device.serializer())
-  polymorphic(Resource::class, DeviceAssociation::class, DeviceAssociation.serializer())
   polymorphic(Resource::class, DeviceDefinition::class, DeviceDefinition.serializer())
-  polymorphic(Resource::class, DeviceDispense::class, DeviceDispense.serializer())
   polymorphic(Resource::class, DeviceMetric::class, DeviceMetric.serializer())
   polymorphic(Resource::class, DeviceRequest::class, DeviceRequest.serializer())
-  polymorphic(Resource::class, DeviceUsage::class, DeviceUsage.serializer())
+  polymorphic(Resource::class, DeviceUseStatement::class, DeviceUseStatement.serializer())
   polymorphic(Resource::class, DiagnosticReport::class, DiagnosticReport.serializer())
+  polymorphic(Resource::class, DocumentManifest::class, DocumentManifest.serializer())
   polymorphic(Resource::class, DocumentReference::class, DocumentReference.serializer())
   polymorphic(Resource::class, Encounter::class, Encounter.serializer())
-  polymorphic(Resource::class, EncounterHistory::class, EncounterHistory.serializer())
   polymorphic(Resource::class, Endpoint::class, Endpoint.serializer())
   polymorphic(Resource::class, EnrollmentRequest::class, EnrollmentRequest.serializer())
   polymorphic(Resource::class, EnrollmentResponse::class, EnrollmentResponse.serializer())
@@ -108,14 +110,11 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, ExplanationOfBenefit::class, ExplanationOfBenefit.serializer())
   polymorphic(Resource::class, FamilyMemberHistory::class, FamilyMemberHistory.serializer())
   polymorphic(Resource::class, Flag::class, Flag.serializer())
-  polymorphic(Resource::class, FormularyItem::class, FormularyItem.serializer())
-  polymorphic(Resource::class, GenomicStudy::class, GenomicStudy.serializer())
   polymorphic(Resource::class, Goal::class, Goal.serializer())
   polymorphic(Resource::class, GraphDefinition::class, GraphDefinition.serializer())
   polymorphic(Resource::class, Group::class, Group.serializer())
   polymorphic(Resource::class, GuidanceResponse::class, GuidanceResponse.serializer())
   polymorphic(Resource::class, HealthcareService::class, HealthcareService.serializer())
-  polymorphic(Resource::class, ImagingSelection::class, ImagingSelection.serializer())
   polymorphic(Resource::class, ImagingStudy::class, ImagingStudy.serializer())
   polymorphic(Resource::class, Immunization::class, Immunization.serializer())
   polymorphic(Resource::class, ImmunizationEvaluation::class, ImmunizationEvaluation.serializer())
@@ -127,8 +126,6 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, ImplementationGuide::class, ImplementationGuide.serializer())
   polymorphic(Resource::class, Ingredient::class, Ingredient.serializer())
   polymorphic(Resource::class, InsurancePlan::class, InsurancePlan.serializer())
-  polymorphic(Resource::class, InventoryItem::class, InventoryItem.serializer())
-  polymorphic(Resource::class, InventoryReport::class, InventoryReport.serializer())
   polymorphic(Resource::class, Invoice::class, Invoice.serializer())
   polymorphic(Resource::class, Library::class, Library.serializer())
   polymorphic(Resource::class, Linkage::class, Linkage.serializer())
@@ -141,6 +138,7 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   )
   polymorphic(Resource::class, Measure::class, Measure.serializer())
   polymorphic(Resource::class, MeasureReport::class, MeasureReport.serializer())
+  polymorphic(Resource::class, Media::class, Media.serializer())
   polymorphic(Resource::class, Medication::class, Medication.serializer())
   polymorphic(
     Resource::class,
@@ -160,7 +158,6 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, MessageHeader::class, MessageHeader.serializer())
   polymorphic(Resource::class, MolecularSequence::class, MolecularSequence.serializer())
   polymorphic(Resource::class, NamingSystem::class, NamingSystem.serializer())
-  polymorphic(Resource::class, NutritionIntake::class, NutritionIntake.serializer())
   polymorphic(Resource::class, NutritionOrder::class, NutritionOrder.serializer())
   polymorphic(Resource::class, NutritionProduct::class, NutritionProduct.serializer())
   polymorphic(Resource::class, Observation::class, Observation.serializer())
@@ -178,7 +175,6 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Patient::class, Patient.serializer())
   polymorphic(Resource::class, PaymentNotice::class, PaymentNotice.serializer())
   polymorphic(Resource::class, PaymentReconciliation::class, PaymentReconciliation.serializer())
-  polymorphic(Resource::class, Permission::class, Permission.serializer())
   polymorphic(Resource::class, Person::class, Person.serializer())
   polymorphic(Resource::class, PlanDefinition::class, PlanDefinition.serializer())
   polymorphic(Resource::class, Practitioner::class, Practitioner.serializer())
@@ -189,8 +185,13 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, QuestionnaireResponse::class, QuestionnaireResponse.serializer())
   polymorphic(Resource::class, RegulatedAuthorization::class, RegulatedAuthorization.serializer())
   polymorphic(Resource::class, RelatedPerson::class, RelatedPerson.serializer())
-  polymorphic(Resource::class, RequestOrchestration::class, RequestOrchestration.serializer())
-  polymorphic(Resource::class, Requirements::class, Requirements.serializer())
+  polymorphic(Resource::class, RequestGroup::class, RequestGroup.serializer())
+  polymorphic(Resource::class, ResearchDefinition::class, ResearchDefinition.serializer())
+  polymorphic(
+    Resource::class,
+    ResearchElementDefinition::class,
+    ResearchElementDefinition.serializer(),
+  )
   polymorphic(Resource::class, ResearchStudy::class, ResearchStudy.serializer())
   polymorphic(Resource::class, ResearchSubject::class, ResearchSubject.serializer())
   polymorphic(Resource::class, RiskAssessment::class, RiskAssessment.serializer())
@@ -207,23 +208,12 @@ private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, SubscriptionTopic::class, SubscriptionTopic.serializer())
   polymorphic(Resource::class, Substance::class, Substance.serializer())
   polymorphic(Resource::class, SubstanceDefinition::class, SubstanceDefinition.serializer())
-  polymorphic(Resource::class, SubstanceNucleicAcid::class, SubstanceNucleicAcid.serializer())
-  polymorphic(Resource::class, SubstancePolymer::class, SubstancePolymer.serializer())
-  polymorphic(Resource::class, SubstanceProtein::class, SubstanceProtein.serializer())
-  polymorphic(
-    Resource::class,
-    SubstanceReferenceInformation::class,
-    SubstanceReferenceInformation.serializer(),
-  )
-  polymorphic(Resource::class, SubstanceSourceMaterial::class, SubstanceSourceMaterial.serializer())
   polymorphic(Resource::class, SupplyDelivery::class, SupplyDelivery.serializer())
   polymorphic(Resource::class, SupplyRequest::class, SupplyRequest.serializer())
   polymorphic(Resource::class, Task::class, Task.serializer())
   polymorphic(Resource::class, TerminologyCapabilities::class, TerminologyCapabilities.serializer())
-  polymorphic(Resource::class, TestPlan::class, TestPlan.serializer())
   polymorphic(Resource::class, TestReport::class, TestReport.serializer())
   polymorphic(Resource::class, TestScript::class, TestScript.serializer())
-  polymorphic(Resource::class, Transport::class, Transport.serializer())
   polymorphic(Resource::class, ValueSet::class, ValueSet.serializer())
   polymorphic(Resource::class, VerificationResult::class, VerificationResult.serializer())
   polymorphic(Resource::class, VisionPrescription::class, VisionPrescription.serializer())

--- a/fhir-model/src/commonMain/kotlin/com/google/fhir/model/r5/FhirR5Json.kt
+++ b/fhir-model/src/commonMain/kotlin/com/google/fhir/model/r5/FhirR5Json.kt
@@ -14,23 +14,41 @@
  * limitations under the License.
  */
 
-package com.google.fhir.model.r4
+package com.google.fhir.model.r5
 
+import kotlin.String
+import kotlin.Unit
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonBuilder
 import kotlinx.serialization.modules.SerializersModule
 
-public fun JsonBuilder.configureR4() {
-  classDiscriminator = "resourceType"
-  serializersModule = serializersModuleR4
+public class FhirR5Json(`init`: JsonBuilder.() -> Unit = {}) {
+  private val json: Json = Json {
+    prettyPrint = true
+    classDiscriminator = "resourceType"
+    serializersModule = serializersModuleR5
+    init()
+  }
+
+  public fun encodeToString(resource: Resource): String = json.encodeToString(resource)
+
+  public fun decodeFromString(string: String): Resource = json.decodeFromString<Resource>(string)
 }
 
-private val serializersModuleR4: SerializersModule = SerializersModule {
+private val serializersModuleR5: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Account::class, Account.serializer())
   polymorphic(Resource::class, ActivityDefinition::class, ActivityDefinition.serializer())
+  polymorphic(Resource::class, ActorDefinition::class, ActorDefinition.serializer())
+  polymorphic(
+    Resource::class,
+    AdministrableProductDefinition::class,
+    AdministrableProductDefinition.serializer(),
+  )
   polymorphic(Resource::class, AdverseEvent::class, AdverseEvent.serializer())
   polymorphic(Resource::class, AllergyIntolerance::class, AllergyIntolerance.serializer())
   polymorphic(Resource::class, Appointment::class, Appointment.serializer())
   polymorphic(Resource::class, AppointmentResponse::class, AppointmentResponse.serializer())
+  polymorphic(Resource::class, ArtifactAssessment::class, ArtifactAssessment.serializer())
   polymorphic(Resource::class, AuditEvent::class, AuditEvent.serializer())
   polymorphic(Resource::class, Basic::class, Basic.serializer())
   polymorphic(Resource::class, Binary::class, Binary.serializer())
@@ -39,17 +57,23 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
     BiologicallyDerivedProduct::class,
     BiologicallyDerivedProduct.serializer(),
   )
+  polymorphic(
+    Resource::class,
+    BiologicallyDerivedProductDispense::class,
+    BiologicallyDerivedProductDispense.serializer(),
+  )
   polymorphic(Resource::class, BodyStructure::class, BodyStructure.serializer())
   polymorphic(Resource::class, Bundle::class, Bundle.serializer())
   polymorphic(Resource::class, CapabilityStatement::class, CapabilityStatement.serializer())
   polymorphic(Resource::class, CarePlan::class, CarePlan.serializer())
   polymorphic(Resource::class, CareTeam::class, CareTeam.serializer())
-  polymorphic(Resource::class, CatalogEntry::class, CatalogEntry.serializer())
   polymorphic(Resource::class, ChargeItem::class, ChargeItem.serializer())
   polymorphic(Resource::class, ChargeItemDefinition::class, ChargeItemDefinition.serializer())
+  polymorphic(Resource::class, Citation::class, Citation.serializer())
   polymorphic(Resource::class, Claim::class, Claim.serializer())
   polymorphic(Resource::class, ClaimResponse::class, ClaimResponse.serializer())
   polymorphic(Resource::class, ClinicalImpression::class, ClinicalImpression.serializer())
+  polymorphic(Resource::class, ClinicalUseDefinition::class, ClinicalUseDefinition.serializer())
   polymorphic(Resource::class, CodeSystem::class, CodeSystem.serializer())
   polymorphic(Resource::class, Communication::class, Communication.serializer())
   polymorphic(Resource::class, CommunicationRequest::class, CommunicationRequest.serializer())
@@ -57,6 +81,7 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Composition::class, Composition.serializer())
   polymorphic(Resource::class, ConceptMap::class, ConceptMap.serializer())
   polymorphic(Resource::class, Condition::class, Condition.serializer())
+  polymorphic(Resource::class, ConditionDefinition::class, ConditionDefinition.serializer())
   polymorphic(Resource::class, Consent::class, Consent.serializer())
   polymorphic(Resource::class, Contract::class, Contract.serializer())
   polymorphic(Resource::class, Coverage::class, Coverage.serializer())
@@ -72,31 +97,36 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
   )
   polymorphic(Resource::class, DetectedIssue::class, DetectedIssue.serializer())
   polymorphic(Resource::class, Device::class, Device.serializer())
+  polymorphic(Resource::class, DeviceAssociation::class, DeviceAssociation.serializer())
   polymorphic(Resource::class, DeviceDefinition::class, DeviceDefinition.serializer())
+  polymorphic(Resource::class, DeviceDispense::class, DeviceDispense.serializer())
   polymorphic(Resource::class, DeviceMetric::class, DeviceMetric.serializer())
   polymorphic(Resource::class, DeviceRequest::class, DeviceRequest.serializer())
-  polymorphic(Resource::class, DeviceUseStatement::class, DeviceUseStatement.serializer())
+  polymorphic(Resource::class, DeviceUsage::class, DeviceUsage.serializer())
   polymorphic(Resource::class, DiagnosticReport::class, DiagnosticReport.serializer())
-  polymorphic(Resource::class, DocumentManifest::class, DocumentManifest.serializer())
   polymorphic(Resource::class, DocumentReference::class, DocumentReference.serializer())
-  polymorphic(Resource::class, EffectEvidenceSynthesis::class, EffectEvidenceSynthesis.serializer())
   polymorphic(Resource::class, Encounter::class, Encounter.serializer())
+  polymorphic(Resource::class, EncounterHistory::class, EncounterHistory.serializer())
   polymorphic(Resource::class, Endpoint::class, Endpoint.serializer())
   polymorphic(Resource::class, EnrollmentRequest::class, EnrollmentRequest.serializer())
   polymorphic(Resource::class, EnrollmentResponse::class, EnrollmentResponse.serializer())
   polymorphic(Resource::class, EpisodeOfCare::class, EpisodeOfCare.serializer())
   polymorphic(Resource::class, EventDefinition::class, EventDefinition.serializer())
   polymorphic(Resource::class, Evidence::class, Evidence.serializer())
+  polymorphic(Resource::class, EvidenceReport::class, EvidenceReport.serializer())
   polymorphic(Resource::class, EvidenceVariable::class, EvidenceVariable.serializer())
   polymorphic(Resource::class, ExampleScenario::class, ExampleScenario.serializer())
   polymorphic(Resource::class, ExplanationOfBenefit::class, ExplanationOfBenefit.serializer())
   polymorphic(Resource::class, FamilyMemberHistory::class, FamilyMemberHistory.serializer())
   polymorphic(Resource::class, Flag::class, Flag.serializer())
+  polymorphic(Resource::class, FormularyItem::class, FormularyItem.serializer())
+  polymorphic(Resource::class, GenomicStudy::class, GenomicStudy.serializer())
   polymorphic(Resource::class, Goal::class, Goal.serializer())
   polymorphic(Resource::class, GraphDefinition::class, GraphDefinition.serializer())
   polymorphic(Resource::class, Group::class, Group.serializer())
   polymorphic(Resource::class, GuidanceResponse::class, GuidanceResponse.serializer())
   polymorphic(Resource::class, HealthcareService::class, HealthcareService.serializer())
+  polymorphic(Resource::class, ImagingSelection::class, ImagingSelection.serializer())
   polymorphic(Resource::class, ImagingStudy::class, ImagingStudy.serializer())
   polymorphic(Resource::class, Immunization::class, Immunization.serializer())
   polymorphic(Resource::class, ImmunizationEvaluation::class, ImmunizationEvaluation.serializer())
@@ -106,15 +136,22 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
     ImmunizationRecommendation.serializer(),
   )
   polymorphic(Resource::class, ImplementationGuide::class, ImplementationGuide.serializer())
+  polymorphic(Resource::class, Ingredient::class, Ingredient.serializer())
   polymorphic(Resource::class, InsurancePlan::class, InsurancePlan.serializer())
+  polymorphic(Resource::class, InventoryItem::class, InventoryItem.serializer())
+  polymorphic(Resource::class, InventoryReport::class, InventoryReport.serializer())
   polymorphic(Resource::class, Invoice::class, Invoice.serializer())
   polymorphic(Resource::class, Library::class, Library.serializer())
   polymorphic(Resource::class, Linkage::class, Linkage.serializer())
   polymorphic(Resource::class, List::class, List.serializer())
   polymorphic(Resource::class, Location::class, Location.serializer())
+  polymorphic(
+    Resource::class,
+    ManufacturedItemDefinition::class,
+    ManufacturedItemDefinition.serializer(),
+  )
   polymorphic(Resource::class, Measure::class, Measure.serializer())
   polymorphic(Resource::class, MeasureReport::class, MeasureReport.serializer())
-  polymorphic(Resource::class, Media::class, Media.serializer())
   polymorphic(Resource::class, Medication::class, Medication.serializer())
   polymorphic(
     Resource::class,
@@ -125,67 +162,34 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
   polymorphic(Resource::class, MedicationKnowledge::class, MedicationKnowledge.serializer())
   polymorphic(Resource::class, MedicationRequest::class, MedicationRequest.serializer())
   polymorphic(Resource::class, MedicationStatement::class, MedicationStatement.serializer())
-  polymorphic(Resource::class, MedicinalProduct::class, MedicinalProduct.serializer())
   polymorphic(
     Resource::class,
-    MedicinalProductAuthorization::class,
-    MedicinalProductAuthorization.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductContraindication::class,
-    MedicinalProductContraindication.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductIndication::class,
-    MedicinalProductIndication.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductIngredient::class,
-    MedicinalProductIngredient.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductInteraction::class,
-    MedicinalProductInteraction.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductManufactured::class,
-    MedicinalProductManufactured.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductPackaged::class,
-    MedicinalProductPackaged.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductPharmaceutical::class,
-    MedicinalProductPharmaceutical.serializer(),
-  )
-  polymorphic(
-    Resource::class,
-    MedicinalProductUndesirableEffect::class,
-    MedicinalProductUndesirableEffect.serializer(),
+    MedicinalProductDefinition::class,
+    MedicinalProductDefinition.serializer(),
   )
   polymorphic(Resource::class, MessageDefinition::class, MessageDefinition.serializer())
   polymorphic(Resource::class, MessageHeader::class, MessageHeader.serializer())
   polymorphic(Resource::class, MolecularSequence::class, MolecularSequence.serializer())
   polymorphic(Resource::class, NamingSystem::class, NamingSystem.serializer())
+  polymorphic(Resource::class, NutritionIntake::class, NutritionIntake.serializer())
   polymorphic(Resource::class, NutritionOrder::class, NutritionOrder.serializer())
+  polymorphic(Resource::class, NutritionProduct::class, NutritionProduct.serializer())
   polymorphic(Resource::class, Observation::class, Observation.serializer())
   polymorphic(Resource::class, ObservationDefinition::class, ObservationDefinition.serializer())
   polymorphic(Resource::class, OperationDefinition::class, OperationDefinition.serializer())
   polymorphic(Resource::class, OperationOutcome::class, OperationOutcome.serializer())
   polymorphic(Resource::class, Organization::class, Organization.serializer())
   polymorphic(Resource::class, OrganizationAffiliation::class, OrganizationAffiliation.serializer())
+  polymorphic(
+    Resource::class,
+    PackagedProductDefinition::class,
+    PackagedProductDefinition.serializer(),
+  )
   polymorphic(Resource::class, Parameters::class, Parameters.serializer())
   polymorphic(Resource::class, Patient::class, Patient.serializer())
   polymorphic(Resource::class, PaymentNotice::class, PaymentNotice.serializer())
   polymorphic(Resource::class, PaymentReconciliation::class, PaymentReconciliation.serializer())
+  polymorphic(Resource::class, Permission::class, Permission.serializer())
   polymorphic(Resource::class, Person::class, Person.serializer())
   polymorphic(Resource::class, PlanDefinition::class, PlanDefinition.serializer())
   polymorphic(Resource::class, Practitioner::class, Practitioner.serializer())
@@ -194,18 +198,13 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
   polymorphic(Resource::class, Provenance::class, Provenance.serializer())
   polymorphic(Resource::class, Questionnaire::class, Questionnaire.serializer())
   polymorphic(Resource::class, QuestionnaireResponse::class, QuestionnaireResponse.serializer())
+  polymorphic(Resource::class, RegulatedAuthorization::class, RegulatedAuthorization.serializer())
   polymorphic(Resource::class, RelatedPerson::class, RelatedPerson.serializer())
-  polymorphic(Resource::class, RequestGroup::class, RequestGroup.serializer())
-  polymorphic(Resource::class, ResearchDefinition::class, ResearchDefinition.serializer())
-  polymorphic(
-    Resource::class,
-    ResearchElementDefinition::class,
-    ResearchElementDefinition.serializer(),
-  )
+  polymorphic(Resource::class, RequestOrchestration::class, RequestOrchestration.serializer())
+  polymorphic(Resource::class, Requirements::class, Requirements.serializer())
   polymorphic(Resource::class, ResearchStudy::class, ResearchStudy.serializer())
   polymorphic(Resource::class, ResearchSubject::class, ResearchSubject.serializer())
   polymorphic(Resource::class, RiskAssessment::class, RiskAssessment.serializer())
-  polymorphic(Resource::class, RiskEvidenceSynthesis::class, RiskEvidenceSynthesis.serializer())
   polymorphic(Resource::class, Schedule::class, Schedule.serializer())
   polymorphic(Resource::class, SearchParameter::class, SearchParameter.serializer())
   polymorphic(Resource::class, ServiceRequest::class, ServiceRequest.serializer())
@@ -215,7 +214,10 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
   polymorphic(Resource::class, StructureDefinition::class, StructureDefinition.serializer())
   polymorphic(Resource::class, StructureMap::class, StructureMap.serializer())
   polymorphic(Resource::class, Subscription::class, Subscription.serializer())
+  polymorphic(Resource::class, SubscriptionStatus::class, SubscriptionStatus.serializer())
+  polymorphic(Resource::class, SubscriptionTopic::class, SubscriptionTopic.serializer())
   polymorphic(Resource::class, Substance::class, Substance.serializer())
+  polymorphic(Resource::class, SubstanceDefinition::class, SubstanceDefinition.serializer())
   polymorphic(Resource::class, SubstanceNucleicAcid::class, SubstanceNucleicAcid.serializer())
   polymorphic(Resource::class, SubstancePolymer::class, SubstancePolymer.serializer())
   polymorphic(Resource::class, SubstanceProtein::class, SubstanceProtein.serializer())
@@ -225,13 +227,14 @@ private val serializersModuleR4: SerializersModule = SerializersModule {
     SubstanceReferenceInformation.serializer(),
   )
   polymorphic(Resource::class, SubstanceSourceMaterial::class, SubstanceSourceMaterial.serializer())
-  polymorphic(Resource::class, SubstanceSpecification::class, SubstanceSpecification.serializer())
   polymorphic(Resource::class, SupplyDelivery::class, SupplyDelivery.serializer())
   polymorphic(Resource::class, SupplyRequest::class, SupplyRequest.serializer())
   polymorphic(Resource::class, Task::class, Task.serializer())
   polymorphic(Resource::class, TerminologyCapabilities::class, TerminologyCapabilities.serializer())
+  polymorphic(Resource::class, TestPlan::class, TestPlan.serializer())
   polymorphic(Resource::class, TestReport::class, TestReport.serializer())
   polymorphic(Resource::class, TestScript::class, TestScript.serializer())
+  polymorphic(Resource::class, Transport::class, Transport.serializer())
   polymorphic(Resource::class, ValueSet::class, ValueSet.serializer())
   polymorphic(Resource::class, VerificationResult::class, VerificationResult.serializer())
   polymorphic(Resource::class, VisionPrescription::class, VisionPrescription.serializer())

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/EqualityTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/EqualityTest.kt
@@ -29,8 +29,8 @@ class EqualityTest {
         }
       )
       .forEach { exampleJson ->
-        val firstResource = jsonR4.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
-        val secondResource = jsonR4.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
+        val firstResource = jsonR4.decodeFromString(exampleJson)
+        val secondResource = jsonR4.decodeFromString(exampleJson)
         assertEquals(firstResource, secondResource)
       }
   }
@@ -43,10 +43,8 @@ class EqualityTest {
         }
       )
       .forEach { exampleJson ->
-        val firstResource =
-          jsonR4B.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
-        val secondResource =
-          jsonR4B.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
+        val firstResource = jsonR4B.decodeFromString(exampleJson)
+        val secondResource = jsonR4B.decodeFromString(exampleJson)
         assertEquals(firstResource, secondResource)
       }
   }
@@ -59,8 +57,8 @@ class EqualityTest {
         }
       )
       .forEach { exampleJson ->
-        val firstResource = jsonR5.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
-        val secondResource = jsonR5.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
+        val firstResource = jsonR5.decodeFromString(exampleJson)
+        val secondResource = jsonR5.decodeFromString(exampleJson)
         assertEquals(firstResource, secondResource)
       }
   }

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/SerializationRoundTripTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/SerializationRoundTripTest.kt
@@ -35,7 +35,7 @@ class SerializationRoundTripTest {
       )
       .forEach {
         val exampleJson = prettyPrintJson(it)
-        val domainResource = jsonR4.decodeFromString<com.google.fhir.model.r4.Resource>(exampleJson)
+        val domainResource = jsonR4.decodeFromString(exampleJson)
         val reserializedString = jsonR4.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
       }
@@ -50,8 +50,7 @@ class SerializationRoundTripTest {
       )
       .forEach {
         val exampleJson = prettyPrintJson(it)
-        val domainResource =
-          jsonR4B.decodeFromString<com.google.fhir.model.r4b.Resource>(exampleJson)
+        val domainResource = jsonR4B.decodeFromString(exampleJson)
         val reserializedString = jsonR4B.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
       }
@@ -66,7 +65,7 @@ class SerializationRoundTripTest {
       )
       .forEach {
         val exampleJson = prettyPrintJson(it)
-        val domainResource = jsonR5.decodeFromString<com.google.fhir.model.r5.Resource>(exampleJson)
+        val domainResource = jsonR5.decodeFromString(exampleJson)
         val reserializedString = jsonR5.encodeToString(domainResource)
         assertEqualsIgnoringZeros(exampleJson, reserializedString)
       }

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/TestJson.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/TestJson.kt
@@ -16,22 +16,12 @@
 
 package com.google.fhir.model.test
 
-import com.google.fhir.model.r4.configureR4
-import com.google.fhir.model.r4b.configureR4b
-import com.google.fhir.model.r5.configureR5
-import kotlinx.serialization.json.Json
+import com.google.fhir.model.r4.FhirR4Json
+import com.google.fhir.model.r4b.FhirR4bJson
+import com.google.fhir.model.r5.FhirR5Json
 
-val jsonR4 = Json {
-  prettyPrint = true
-  configureR4()
-}
+val jsonR4 = FhirR4Json()
 
-val jsonR4B = Json {
-  prettyPrint = true
-  configureR4b()
-}
+val jsonR4B = FhirR4bJson()
 
-val jsonR5 = Json {
-  prettyPrint = true
-  configureR5()
-}
+val jsonR5 = FhirR5Json()


### PR DESCRIPTION
Fixes #23

In this PR we improve the public API for JSON serialization and deserialization by providing new classes `FhirR4Json` `FhirR4bJson` and `FhirR5Json`:

```
import com.google.fhir.model.r4.FhirR4Json  // or com.google.fhir.model.r4b.FhirR4bJson or com.google.fhir.model.r5.FhirR5Json

val jsonR4 = FhirR4Json()
val jsonString = jsonR4.encodeToString(patient)  // Serialization
val reconstructedPatient = jsonR4.decodeFromString(jsonString)  // Deserialization
```

Compared with the old API:

```
import com.google.fhir.model.r4.configureR4 // or com.google.fhir.model.r4b.configureR4b or com.google.fhir.model.r5.configureR5

val json = Json {
    configureR4()  // or configureR4b() or configureR5()
}
val jsonString = json.encodeToString<Resource>(patient)  // Serialization
val reconstructedPatient = json.decodeFromString<Resource>(jsonString)  // Deserialization
```

this API has the following major benefits:

1. Less initial setup: no need to explicitly call the `configureR4`, `configureR4b` or `configureR5` functions. Just use the provided class and you're good to go.
2. More type-safe and less error-prone: no need to specify the type parameter when calling `encodeToString` and `decodeFromString` functions, removing a significant complexity.

Additionally, the constructor of the new class takes an optional lambda for further configuring the `Json` serialization object provided by the `kotlinx.serialization` library. So no functionality is lost in this change.

This PR also updates the README file, including the removal of a huge section on polymorphism. This section is no longer needed since this complexity is now hidden from the user, making the library easier to use.