### PR TITLE
Use enabled flag to skip tests with reason

### DIFF
--- a/fhir-model/build.gradle.kts
+++ b/fhir-model/build.gradle.kts
@@ -132,6 +132,9 @@ kotlin {
         val androidMain by getting
         val androidUnitTest by getting {
             dependsOn(commonTest)
+            dependencies {
+                implementation(libs.kotest.runner.junit5)
+            }
         }
         val jvmMain by getting
         val jvmTest by getting {
@@ -151,21 +154,19 @@ android {
         minSdk = libs.versions.android.minSdk.get().toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-    sourceSets {
-        getByName("androidTest") {
-            // Make third party package available to Android instrumented tests
-            val projectRootPath = project.rootDir.absolutePath
-            assets.srcDir("$projectRootPath/third_party")
+    testOptions {
+        unitTests.all { test ->
+            // Allow tests to access third_party
+            test.systemProperty("projectRootDir", project.rootDir.absolutePath)
+            test.maxHeapSize = "4g"
+            test.useJUnitPlatform()
         }
     }
 }
 
-tasks.withType<Test>().configureEach {
+tasks.named<Test>("jvmTest") {
     // Allow tests to access third_party
     systemProperty("projectRootDir", project.rootDir.absolutePath)
-}
-
-tasks.named<Test>("jvmTest") {
     maxHeapSize = "4g"
     useJUnitPlatform()
 }

--- a/fhir-model/src/androidUnitTest/kotlin/com/google/fhir/model/test/TestLoader.android.kt
+++ b/fhir-model/src/androidUnitTest/kotlin/com/google/fhir/model/test/TestLoader.android.kt
@@ -18,25 +18,13 @@ package com.google.fhir.model.test
 
 import java.io.File
 
-actual fun loadR4Examples(fileNameFilter: (String) -> Boolean): Sequence<String> {
-  return loadExamplesFromFileSystem(r4ExamplePackage, fileNameFilter)
-}
-
-actual fun loadR4BExamples(fileNameFilter: (String) -> Boolean): Sequence<String> {
-  return loadExamplesFromFileSystem(r4bExamplePackage, fileNameFilter)
-}
-
-actual fun loadR5Examples(fileNameFilter: (String) -> Boolean): Sequence<String> {
-  return loadExamplesFromFileSystem(r5ExamplePackage, fileNameFilter)
-}
-
-private fun loadExamplesFromFileSystem(
-  directoryName: String,
+actual fun loadExamplesFromFileSystem(
+  packageSubdirectory: String,
   fileNameFilter: (String) -> Boolean,
-): Sequence<String> {
-  return File("${System.getProperty("projectRootDir")}/third_party/${directoryName}")
+): Sequence<FhirResourceJsonExample> {
+  return File("${System.getProperty("projectRootDir")}/third_party/${packageSubdirectory}")
     .listFiles()!!
     .asSequence()
     .filter { fileNameFilter(it.name) }
-    .map { it.readText() }
+    .map { FhirResourceJsonExample(it.name, it.readText()) }
 }

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/EqualityTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/EqualityTest.kt
@@ -17,57 +17,77 @@
 package com.google.fhir.model.test
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.Enabled
 import kotlin.test.assertEquals
+
+/** A map from the test case name to the reason why the test case is skipped in R4. */
+private val skippedR4TestCaseNameToReasonMap =
+  mapOf(
+    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resource",
+    "ImplementationGuide-fhir.json" to "Invalid resource",
+    "Questionnaire-qs1.json" to "Invalid resource",
+    "ig-r4.json" to "Invalid resource",
+  )
+
+/** A map from the test case name to the reason why the test case is skipped in R4B. */
+private val skippedR4BTestCaseNameToReasonMap =
+  mapOf(
+    "Bundle-valuesets.json" to "Invalid resource",
+    "CodeSystem-catalogType.json" to "Invalid resource",
+    "ValueSet-catalogType.json" to "Invalid resource",
+    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resource",
+  )
+
+/** A map from the test case name to the reason why the test case is skipped in R5. */
+private val skippedR5TestCaseNameToReasonMap =
+  mapOf(
+    "ChargeItemDefinition-ebm.json" to
+      "Unknown code 'text/CQL' for enum ExpressionLanguage; codes are case-sensitive"
+  )
 
 class EqualityTest :
   FunSpec({
     listOf(
-        EqualityTestSuite("R4", ::loadR4Examples, exclusionListR4, jsonR4::decodeFromString),
-        EqualityTestSuite("R4B", ::loadR4BExamples, exclusionListR4B, jsonR4B::decodeFromString),
-        EqualityTestSuite("R5", ::loadR5Examples, exclusionListR5, jsonR5::decodeFromString),
+        EqualityTestSuite(
+          "R4",
+          ::loadR4Examples,
+          skippedR4TestCaseNameToReasonMap,
+          jsonR4::decodeFromString,
+        ),
+        EqualityTestSuite(
+          "R4B",
+          ::loadR4BExamples,
+          skippedR4BTestCaseNameToReasonMap,
+          jsonR4B::decodeFromString,
+        ),
+        EqualityTestSuite(
+          "R5",
+          ::loadR5Examples,
+          skippedR5TestCaseNameToReasonMap,
+          jsonR5::decodeFromString,
+        ),
       )
       .forEach { testSuite ->
         context("${testSuite.fhirVersion} resources should be equal") {
-          testSuite
-            .exampleLoader { filterFileName(it) && !testSuite.exclusionList.contains(it) }
-            .forEach { (fileName, json) ->
-              test(fileName) {
-                val firstResource = testSuite.decodeFunction(json)
-                val secondResource = testSuite.decodeFunction(json)
-                assertEquals(firstResource, secondResource)
+          testSuite.exampleLoader().forEach { (fileName, json) ->
+            test(fileName).config(
+              enabledOrReasonIf = {
+                testSuite.skippedTestCaseNameToReasonMap[fileName]?.let { Enabled.disabled(it) }
+                  ?: Enabled.enabled
               }
+            ) {
+              val firstResource = testSuite.decodeFunction(json)
+              val secondResource = testSuite.decodeFunction(json)
+              assertEquals(firstResource, secondResource)
             }
+          }
         }
       }
   })
 
 private data class EqualityTestSuite(
   val fhirVersion: String,
-  val exampleLoader: (filter: (String) -> Boolean) -> Sequence<FhirResourceJsonExample>,
-  val exclusionList: List<String>,
+  val exampleLoader: () -> Sequence<FhirResourceJsonExample>,
+  val skippedTestCaseNameToReasonMap: Map<String, String>,
   val decodeFunction: (String) -> Any,
 )
-
-private val exclusionListR4 =
-  listOf(
-    // Invalid resources
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json",
-    "ImplementationGuide-fhir.json",
-    "Questionnaire-qs1.json",
-    "ig-r4.json",
-  )
-
-private val exclusionListR4B =
-  listOf(
-    // Invalid resource
-    "Bundle-valuesets.json",
-    "CodeSystem-catalogType.json",
-    "ValueSet-catalogType.json",
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json",
-  )
-
-private val exclusionListR5 =
-  listOf(
-    // Unknown code 'text/CQL' for enum ExpressionLanguage; codes are case-sensitive
-    "ChargeItemDefinition-ebm.json"
-  )

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/SimpleSerializationTest.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/SimpleSerializationTest.kt
@@ -22,6 +22,7 @@ import com.google.fhir.model.r5.FhirR5Json
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
+/** See https://github.com/google/kotlin-fhir/issues/66. */
 class SimpleSerializationTest :
   FunSpec({
     test("Serialized resource in R4 should have resourceType property") {

--- a/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/TestLoader.kt
+++ b/fhir-model/src/commonTest/kotlin/com/google/fhir/model/test/TestLoader.kt
@@ -16,21 +16,34 @@
 
 package com.google.fhir.model.test
 
-const val r4ExamplePackage = "hl7.fhir.r4.examples/package/"
-const val r4bExamplePackage = "hl7.fhir.r4b.examples/package/"
-const val r5ExamplePackage = "hl7.fhir.r5.examples/package/"
+data class FhirResourceJsonExample(val fileName: String, val json: String)
 
-fun filterFileName(name: String): Boolean {
+fun loadR4Examples(): Sequence<FhirResourceJsonExample> =
+  loadExamplesFromFileSystem(
+    packageSubdirectory = "hl7.fhir.r4.examples/package/",
+    ::filterFileName,
+  )
+
+fun loadR4BExamples(): Sequence<FhirResourceJsonExample> =
+  loadExamplesFromFileSystem(
+    packageSubdirectory = "hl7.fhir.r4b.examples/package/",
+    ::filterFileName,
+  )
+
+fun loadR5Examples(): Sequence<FhirResourceJsonExample> =
+  loadExamplesFromFileSystem(
+    packageSubdirectory = "hl7.fhir.r5.examples/package/",
+    ::filterFileName,
+  )
+
+expect fun loadExamplesFromFileSystem(
+  packageSubdirectory: String,
+  fileNameFilter: (String) -> Boolean,
+): Sequence<FhirResourceJsonExample>
+
+private fun filterFileName(name: String): Boolean {
   return name.endsWith(".json") &&
     !name.startsWith('.') // filter out `.index.json` file
     &&
     name != "package.json"
 }
-
-data class FhirResourceJsonExample(val fileName: String, val json: String)
-
-expect fun loadR4Examples(fileNameFilter: (String) -> Boolean): Sequence<FhirResourceJsonExample>
-
-expect fun loadR4BExamples(fileNameFilter: (String) -> Boolean): Sequence<FhirResourceJsonExample>
-
-expect fun loadR5Examples(fileNameFilter: (String) -> Boolean): Sequence<FhirResourceJsonExample>

--- a/fhir-model/src/jvmTest/kotlin/com/google/fhir/model/test/TestLoader.jvm.kt
+++ b/fhir-model/src/jvmTest/kotlin/com/google/fhir/model/test/TestLoader.jvm.kt
@@ -18,25 +18,13 @@ package com.google.fhir.model.test
 
 import java.io.File
 
-private fun loadExamplesFromFileSystem(
-  directoryName: String,
+actual fun loadExamplesFromFileSystem(
+  packageSubdirectory: String,
   fileNameFilter: (String) -> Boolean,
 ): Sequence<FhirResourceJsonExample> {
-  return File("${System.getProperty("projectRootDir")}/third_party/${directoryName}")
+  return File("${System.getProperty("projectRootDir")}/third_party/${packageSubdirectory}")
     .listFiles()!!
     .asSequence()
     .filter { fileNameFilter(it.name) }
     .map { FhirResourceJsonExample(it.name, it.readText()) }
-}
-
-actual fun loadR4Examples(fileNameFilter: (String) -> Boolean): Sequence<FhirResourceJsonExample> {
-  return loadExamplesFromFileSystem(r4ExamplePackage, fileNameFilter)
-}
-
-actual fun loadR4BExamples(fileNameFilter: (String) -> Boolean): Sequence<FhirResourceJsonExample> {
-  return loadExamplesFromFileSystem(r4bExamplePackage, fileNameFilter)
-}
-
-actual fun loadR5Examples(fileNameFilter: (String) -> Boolean): Sequence<FhirResourceJsonExample> {
-  return loadExamplesFromFileSystem(r5ExamplePackage, fileNameFilter)
 }


### PR DESCRIPTION
Instead of naively skipping tests by the test name, this PR introduces [enabled flag](https://kotest.io/docs/framework/conditional/enabled-config-flag.html) to skip test cases and provide reasons.

This is more explicit and helps keep track of skipped tests and the reasons.

Also:
- Refactor the test setup to reduce duplicated expect functions
- Fix the android unit tests by adding correct test runner dependency