### PR TITLE
Set up release to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,22 +626,55 @@ These tests are set up to run on JVM and as Android unit tests. To run them loca
 
 ### Publishing
 
-To create a maven repository from the generated FHIR model, run:
+For a comprehensive understanding of publishing KMP libraries to Maven Central, see the
+[Kotlin Multiplatform Publishing Guide](https://kotlinlang.org/docs/multiplatform-publish-lib.html)
+and the
+[Maven Central Publishing Guide](https://central.sonatype.org/publish/publish-portal-guide/).
 
+> **Note:** The project has already been set up to be released to Maven using the
+> [`gradle-maven-publish-plugin`](https://github.com/vanniktech/gradle-maven-publish-plugin). The
+> following sections outline the additional setup required for a developer to publish to Maven Local
+> and Maven Central.
+
+#### Maven Local
+To publish artifacts to your local Maven repository (`~/.m2/repository`) for local development and
+testing, run:
+
+```bash
+./gradlew :fhir-model:publishToMavenLocal
 ```
-./gradlew :fhir-model:publish
+
+#### Maven Central
+To publish a new release to Maven Central, first set up your GPG signing key and repository
+credentials to Gradle following the aforementioned official guides.
+
+**Best Practice**: Store these sensitive details in your **Global Gradle Properties** file at
+`~/.gradle/gradle.properties` (User Home directory). This ensures they are available to all your
+projects but are never accidentally committed to the Git repository.
+
+Your `~/.gradle/gradle.properties` should contain:
+
+```properties
+# Maven Central Credentials
+mavenCentralUsername=YOUR_USERNAME
+mavenCentralPassword=YOUR_PASSWORD
+
+# GPG Key Details
+signing.keyId=YOUR_KEY_ID
+signing.password=YOUR_KEY_PASSWORD
+signing.secretKeyRingFile=/path/to/secring.gpg
 ```
 
-This will create a maven repository in the `fhir-model/build/repo` directory with artifacts for all
-supported platforms.
-
-To zip the repository, run:
-
-```
-./gradlew :fhir-model:zipRepo
+You can verify your signing setup by running:
+```bash
+./gradlew :fhir-model:checkSigningConfiguration
 ```
 
-This will generate a `.zip` file in the `fhir-model/build/repoZip` directory.
+To publish to Maven Central, run:
+
+```bash
+./gradlew :fhir-model:publishToMavenCentral
+```
 
 ## Acknowledgements
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.maven.publish) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.spotless)
 }

--- a/fhir-model/build.gradle.kts
+++ b/fhir-model/build.gradle.kts
@@ -7,6 +7,7 @@ import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
 
 plugins {
     alias(libs.plugins.android.library)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotest)
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlinx.serialization)
@@ -14,9 +15,6 @@ plugins {
     id("fhir-codegen")
     `maven-publish`
 }
-
-group = MAVEN_GROUP_ID
-version = "1.0.0-beta03"
 
 // Run `./gradlew r4` to generate FHIR models for R4 in `fhir-model/build/generated/r4`
 val codegenTaskR4 = fhirCodegenExtension.newTask("r4") {
@@ -174,43 +172,34 @@ tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
 }
 
-// publishing prep
-val localRepo: Directory = project.layout.buildDirectory.get().dir("repo")
-publishing {
-    repositories {
-        maven {
-            url = localRepo.asFile.toURI()
-        }
-    }
-    publications {
-        withType<MavenPublication> {
-            pom {
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
+version = "1.0.0-beta03"
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+    coordinates(MAVEN_GROUP_ID, "fhir-model", version.toString())
+    pom {
+        name = "Kotlin FHIR"
+        description = "A Kotlin Multiplatform library for FHIR data model"
+        inceptionYear = "2025"
+        url = "https://github.com/ohs-foundation/kotlin-fhir"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
             }
         }
+        developers {
+            developer {
+                id = "ohs-foundation"
+                name = "Open Heath Stack Foundation"
+                url = "https://ohs.dev/"
+            }
+        }
+        scm {
+            url = "https://github.com/ohs-foundation/kotlin-fhir/"
+            connection = "scm:git:git://github.com/ohs-foundation/kotlin-fhir.git"
+            developerConnection = "scm:git:ssh://git@github.com/ohs-foundation/kotlin-fhir.git"
+        }
     }
-}
-val deleteRepoTask = tasks.register<Delete>("deleteLocalRepo") {
-    description =
-        "Deletes the local repository to get rid of stale artifacts before local publishing"
-    this.delete(localRepo)
-}
-tasks.named("publishAllPublicationsToMavenRepository").configure {
-    dependsOn(deleteRepoTask)
-}
-tasks.register("zipRepo", Zip::class) {
-    description = "Create a zip of the maven repository"
-    this.destinationDirectory.set(project.layout.buildDirectory.dir("repoZip"))
-    archiveBaseName.set("kotlin-fhir")
-
-    // Hint to gradle that the repo files are produced by the publish task. This establishes a
-    // dependency from the zipRepo task to the publish task.
-    this.from(tasks.named("publish").map { _ ->
-        localRepo
-    })
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ kotlin.mpp.enableCInteropCommonization=true
 android.useAndroidX=true
 android.nonTransitiveRClass=true
 android.enableJetifier=false
+io.kotest.multiplatform.compiler.plugin.enabled=false
+kotest.compiler.plugin.enabled=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,15 @@
 [versions]
-android-gradle-plugin = "8.10.0"
+android-gradle-plugin = "8.13.0"
 android-compileSdk = "35"
 android-minSdk = "24"
 bignum = "0.3.10"
-kotest = "5.9.1"
-kotlin = "2.2.0"
+kotest = "6.1.11"
+kotlin = "2.3.20"
+ksp = "2.3.6"
 kotlin-poet = "2.0.0"
 kotlinx-datetime = "0.7.1"
 kotlinx-serialization-json = "1.8.1"
-maven-publish = "0.29.0"
+maven-publish = "0.36.0"
 spotless = "7.0.1"
 
 [libraries]
@@ -16,6 +17,7 @@ bignum = { group = "com.ionspin.kotlin", name = "bignum", version.ref = "bignum"
 kotest-assertions-json = { module = "io.kotest:kotest-assertions-json", version.ref = "kotest" }
 kotest-framework-engine = {module = "io.kotest:kotest-framework-engine", version.ref = "kotest"}
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "kotest" }
+ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
@@ -23,9 +25,10 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }
-kotest = { id = "io.kotest.multiplatform", version.ref = "kotest" }
+kotest = { id = "io.kotest", version.ref = "kotest" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
- Update Kotlin version to 2.3.20
- Update AGP to 8.13.0
- Update Kotest to 6.1.11
- Update the Maven Publish plugin to 0.36.0
- Introduce KSP plugin (required by Kotest)
- Set up Maven publish tasks
- Update documentation
