### PR TITLE
Reenable passing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ follows:
 > [Kotlin Multiplatform BigNum](https://github.com/ionspin/kotlin-multiplatform-bignum)
 > library's `BigDecimal` is used to preserve and respect the precision of decimal values as required
 > by the specification. See the notes section in [Datatypes](https://hl7.org/fhir/datatypes.html).
-
+>
 > [!NOTE]
 > The `System.Date` and `System.DateTime` types are mapped to sealed interfaces
 > `FhirDate` and `FhirDateTime` specifically generated to handle partial dates in FHIR. They are
@@ -295,7 +295,7 @@ types are represented by two JSON properties (e.g.
 in [R4](https://hl7.org/fhir/R4/json.html#primitive)). As a result, the Kotlin data class of any
 FHIR resource or element containing primitive data types cannot be directly mapped to JSON.
 
-To address this, the library generates one hand-rolled `KSerializer` per FHIR type (e.g.
+To address this, the library generates a custom `KSerializer` per FHIR type (e.g.
 `PatientSerializer`). Each serializer describes the flat FHIR JSON wire shape via
 `buildClassSerialDescriptor` — one descriptor slot per wire key, including the `_field` sidecar
 keys for primitive extensions (e.g. `gender` + `_gender`).
@@ -464,17 +464,17 @@ plugin (to deserialize FHIR spec JSON) and runtime dependencies (`bignum`, `kotl
 KotlinPoet) that `buildSrc` cannot cleanly support.
 
 - the model class (the primary class) in the root package e.g. `dev.ohs.fhir.model.r4`, and
-- a hand-rolled streaming `KSerializer` per type (e.g. `PatientSerializer`, plus one per
-  BackboneElement) in the serializer package e.g. `dev.ohs.fhir.model.r4.serializers`. Resource
-  types additionally get a thin `XPolymorphicSerializer` (descriptor without `resourceType`) used
-  by `ResourcePolymorphicSerializer` for class-discriminator dispatch.
+- a custom `KSerializer` per type (e.g. `PatientSerializer`, plus one per BackboneElement) in the
+  serializer package e.g. `dev.ohs.fhir.model.r4.serializers`. Resource types additionally get a
+  thin `XPolymorphicSerializer` (descriptor without `resourceType`) used by
+  `ResourcePolymorphicSerializer` for class-discriminator dispatch.
 
 using
 [`ModelFileSpecGenerator`](fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/ModelFileSpecGenerator.kt)
 and
 [`SerializerFileSpecGenerator`](fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/SerializerFileSpecGenerator.kt),
-respectively. Each generated serializer streams
-against kotlinx's `CompositeEncoder` / `CompositeDecoder` over the flat FHIR JSON wire shape.
+respectively. Each generated serializer encodes and decodes sequentially via kotlinx's
+`CompositeEncoder` / `CompositeDecoder` over the flat FHIR JSON wire shape.
 
 Additionally,
 the [`schema`](fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/schema) package in
@@ -783,21 +783,32 @@ This section is for developers who want to contribute to the library.
 
 ### Running the codegen locally
 
-You can run the codegen locally to generate FHIR models for all supported FHIR versions at once[^6]:
-
-[^6]: To generate FHIR models for a specific version, run
-`./gradlew :fhir-model-<FHIR_VERSION>:codegen` where `<FHIR_VERSION>`∈ {`r4`, `r4b`, `r5`}.
+You can run the codegen locally to generate FHIR models for all supported FHIR versions at once, or
+for a specific FHIR version:
 
 ```bash
-# Generate models for a specific FHIR version:
-./gradlew :fhir-model-r4:codegen
-
-# Or generate all FHIR versions at once:
+# Generate models for all FHIR versions (R4, R4B, R5) at once:
 ./gradlew codegen
+
+# Generate models for a specific FHIR version (r4, r4b, or r5):
+./gradlew :fhir-model-<FHIR_VERSION>:codegen
 ```
 
 This will sync all generated code into each module's `src/commonMain/kotlin` directory and apply
 consistent formatting using the [`spotless`](https://github.com/diffplug/spotless) plugin.
+
+#### Verifying generated code
+
+Before pushing changes, you can verify that the committed FHIR models are up-to-date with the
+codegen:
+
+```bash
+./gradlew verifyCodegen
+```
+
+This task regenerates the FHIR models and checks if the output differs from the committed code in
+Git. If this task fails, it means there are changes in the generated output that need to be
+committed.
 
 > [!NOTE]
 > The library is designed for use as a dependency. Directly copying generated code into

--- a/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/BuilderRoundTripTest.kt
+++ b/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/BuilderRoundTripTest.kt
@@ -27,7 +27,6 @@ import kotlin.test.assertEquals
 /** A map from the test case name to the reason why the test case is skipped in R4. */
 private val skippedR4TestCaseNameToReasonMap =
   mapOf(
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resources",
     "ImplementationGuide-fhir.json" to "Invalid resources",
     "Questionnaire-qs1.json" to "Invalid resources",
     "ig-r4.json" to "Invalid resources",
@@ -39,7 +38,6 @@ private val skippedR4BTestCaseNameToReasonMap =
     "Bundle-valuesets.json" to "Invalid resources",
     "CodeSystem-catalogType.json" to "Invalid resources",
     "ValueSet-catalogType.json" to "Invalid resources",
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resources",
   )
 
 /** A map from the test case name to the reason why the test case is skipped in R5. */

--- a/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/EqualityTest.kt
+++ b/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/EqualityTest.kt
@@ -26,7 +26,6 @@ import kotlin.test.assertEquals
 /** A map from the test case name to the reason why the test case is skipped in R4. */
 private val skippedR4TestCaseNameToReasonMap =
   mapOf(
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resource",
     "ImplementationGuide-fhir.json" to "Invalid resource",
     "Questionnaire-qs1.json" to "Invalid resource",
     "ig-r4.json" to "Invalid resource",
@@ -38,7 +37,6 @@ private val skippedR4BTestCaseNameToReasonMap =
     "Bundle-valuesets.json" to "Invalid resource",
     "CodeSystem-catalogType.json" to "Invalid resource",
     "ValueSet-catalogType.json" to "Invalid resource",
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resource",
   )
 
 /** A map from the test case name to the reason why the test case is skipped in R5. */

--- a/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/SerializationRoundTripTest.kt
+++ b/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/SerializationRoundTripTest.kt
@@ -34,15 +34,6 @@ import kotlinx.serialization.serializer
 /** A map from the test case name to the reason why the test case is skipped in R4. */
 private val skippedR4TestCaseNameToReasonMap =
   mapOf(
-    "Bundle-terminologies.json" to "Hanging",
-    "CodeSystem-v2-0003.json" to "Hanging",
-    "Bundle-valueset-expansions.json" to "Hanging",
-    "Bundle-resources.json" to "Java heap space",
-    "Bundle-dataelements.json" to "Java heap space",
-    "CodeSystem-v3-ManagedParticipationStatus.json" to "Java heap space",
-    "ValueSet-v3-hl7PublishingSubSection.json" to "Instant with trailing 0s",
-    "Observation-decimal.json" to "Scientific notation",
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resources",
     "ImplementationGuide-fhir.json" to "Invalid resources",
     "Questionnaire-qs1.json" to "Invalid resources",
     "ig-r4.json" to "Invalid resources",
@@ -51,24 +42,16 @@ private val skippedR4TestCaseNameToReasonMap =
 /** A map from the test case name to the reason why the test case is skipped in R4B. */
 private val skippedR4BTestCaseNameToReasonMap =
   mapOf(
-    "Bundle-resources.json" to "Java heap space",
-    "Observation-decimal.json" to "Scientific notation",
     "Bundle-valuesets.json" to "Invalid resources",
     "CodeSystem-catalogType.json" to "Invalid resources",
     "ValueSet-catalogType.json" to "Invalid resources",
-    "ActivityDefinition-administer-zika-virus-exposure-assessment.json" to "Invalid resources",
   )
 
 /** A map from the test case name to the reason why the test case is skipped in R5. */
 private val skippedR5CaseNameToReasonMap =
   mapOf(
-    "Bundle-searchParams.json" to "Hanging",
-    "Bundle-resources.json" to "Java heap space",
-    "ArtifactAssessment-example-certainty-rating.json" to "Trailing 0 in milliseconds",
-    "Citation-citation-example-research-doi.json" to "Trailing 0 in milliseconds",
-    "Observation-decimal.json" to "Scientific notation",
     "ChargeItemDefinition-ebm.json" to
-      "Unknown code 'text/CQL' for enum ExpressionLanguage; codes are case-sensitive",
+      "Unknown code 'text/CQL' for enum ExpressionLanguage; codes are case-sensitive"
   )
 
 private val plainJson = Json { prettyPrint = true }
@@ -166,6 +149,46 @@ class SerializationRoundTripTest :
           }
         }
       }
+
+    context("removeTrailingZerosInFractionalSeconds") {
+      test("entirely zero fractional seconds are stripped") {
+        assertEquals(
+          "2026-06-16T09:40:48Z",
+          "2026-06-16T09:40:48.000Z".removeTrailingZerosInFractionalSeconds(),
+        )
+        assertEquals(
+          "2026-06-16T09:40:48+01:00",
+          "2026-06-16T09:40:48.000+01:00".removeTrailingZerosInFractionalSeconds(),
+        )
+        assertEquals(
+          "2026-06-16T09:40:48-05:00",
+          "2026-06-16T09:40:48.000-05:00".removeTrailingZerosInFractionalSeconds(),
+        )
+      }
+
+      test("trailing zeros in fractional seconds are trimmed") {
+        assertEquals(
+          "2026-06-16T09:40:48.12Z",
+          "2026-06-16T09:40:48.1200Z".removeTrailingZerosInFractionalSeconds(),
+        )
+        assertEquals(
+          "2026-06-16T09:40:48.12+01:00",
+          "2026-06-16T09:40:48.1200+01:00".removeTrailingZerosInFractionalSeconds(),
+        )
+        assertEquals(
+          "2026-06-16T09:40:48.12-05:00",
+          "2026-06-16T09:40:48.1200-05:00".removeTrailingZerosInFractionalSeconds(),
+        )
+      }
+
+      test("decimal numbers are not modified") {
+        assertEquals(
+          "0.0000000000000000000001",
+          "0.0000000000000000000001".removeTrailingZerosInFractionalSeconds(),
+        )
+        assertEquals("1.0000000", "1.0000000".removeTrailingZerosInFractionalSeconds())
+      }
+    }
   })
 
 private data class SerializationRoundTripTestSuite(
@@ -178,9 +201,9 @@ private data class SerializationRoundTripTestSuite(
 private fun assertEqualsIgnoringZeros(exampleJson: String, reserializedString: String) {
   val expected =
     exampleJson
-      .removeZeroMilliseconds()
+      .removeTrailingZerosInFractionalSeconds()
       .replace("+00:00", "Z") // Unify UTC offset representation for Z
-  val actual = reserializedString.removeZeroMilliseconds()
+  val actual = reserializedString.removeTrailingZerosInFractionalSeconds()
   val expectedJson = plainJson.parseToJsonElement(expected)
   val actualJson = plainJson.parseToJsonElement(actual)
   assertJsonEquals(expectedJson, actualJson)
@@ -225,13 +248,12 @@ private fun assertJsonEquals(expected: JsonElement, actual: JsonElement) {
   }
 }
 
-private val zeroMillisecondsPlusRegex = "\\.000\\+".toRegex()
-private val zeroMillisecondsMinusRegex = "\\.000-".toRegex()
-private val zeroMillisecondsZRegex = "\\.000Z".toRegex()
-private val longZeroMillisecondsZRegex = "\\.0000000".toRegex()
+// Matches trailing zeros in fractional seconds, e.g. ".1200Z" -> ".12Z" (preserves the non-zero
+// digits before the trailing zeros)
+private val trailingZerosInFractionalSeconds = "(\\.\\d*?[1-9])0+(?=[Z+\\-])".toRegex()
 
-private fun String.removeZeroMilliseconds(): String =
-  replace(zeroMillisecondsPlusRegex, "+")
-    .replace(zeroMillisecondsMinusRegex, "-")
-    .replace(zeroMillisecondsZRegex, "Z")
-    .replace(longZeroMillisecondsZRegex, "")
+// Matches fractional seconds that are entirely zeros, e.g. ".000Z" -> "Z"
+private val zeroFractionalSeconds = "\\.0+(?=[Z+\\-])".toRegex()
+
+private fun String.removeTrailingZerosInFractionalSeconds(): String =
+  replace(trailingZerosInFractionalSeconds, "$1").replace(zeroFractionalSeconds, "")


### PR DESCRIPTION
As a result of recent changes (e.g. #83) some test exclusions are no longer needed.

Also simplify the regex for removing trailing zeros in milliseconds.

Minor improvements in README file.