### PR TITLE
Upgrade kotlinx.serialization and KotlinPoet

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,18 +3,16 @@ android-gradle-plugin = "8.13.0"
 android-compileSdk = "35"
 android-minSdk = "24"
 bignum = "0.3.10"
-kotest = "6.1.11"
+kotest = "6.2.0"
 kotlin = "2.3.20"
-kotlin-poet = "2.0.0"
-kotlinx-datetime = "0.7.1"
-kotlinx-serialization-json = "1.8.1"
-kotlinx-serialization-protobuf = "1.8.1"
+kotlin-poet = "2.3.0"
+kotlinx-datetime = "0.8.0"
+kotlinx-serialization = "1.11.0"
 ksp = "2.3.6"
 maven-publish = "0.36.0"
 spotless = "7.0.1"
 
 [libraries]
-# Plugin implementation JARs (used by buildSrc convention plugins)
 android-gradle-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-serialization-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin" }
@@ -30,9 +28,8 @@ ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = 
 kotlin-poet = { module = "com.squareup:kotlinpoet", version.ref = "kotlin-poet" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
-kotlinx-serialization-protobuf = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization-protobuf" }
-
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-serialization-protobuf = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-protobuf", version.ref = "kotlinx-serialization" }
 
 [plugins]
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin" }


### PR DESCRIPTION
Pulling in new dependencies for fixes and improvements:

- `kotlinx.serialization` from 1.8.1 to 1.11.0
- KotlinPoet from 2.0.0 to 2.3.0
- Kotest from 6.1.11 to 6.2.0
- `kotlinx.date` from 0.7.1 to 0.8.0
