### PR TITLE
Fix no such reference origin/main on publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Fetch origin/main for Spotless ratchet
+        run: git fetch origin main
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
Fixes #<issue_number_goes_here>

Error log:
```
* What went wrong:
Could not determine the dependencies of task ':spotlessApply'.
> Could not create task ':spotlessFlexmarkApply'.
   > Could not create task ':spotlessFlexmark'.
      > No such reference 'origin/main'
```

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
