### PR TITLE
Cap Gradle memory in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,18 @@ jobs:
           distribution: 'zulu'
           java-version: 21
       - name: Publish to MavenCentral
-        run: ./gradlew publishToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_KEY_CONTENTS }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+          GRADLE_OPTS: -Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+        run: >-
+          ./gradlew publishToMavenCentral
+          --no-daemon
+          --no-parallel
+          --no-configuration-cache
+          -Dorg.gradle.jvmargs="-Xmx6g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8"
+          -Dorg.gradle.workers.max=1
+          -Dkotlin.daemon.enabled=false
 


### PR DESCRIPTION
Fixes error log on publishing:
```
* What went wrong:
Gradle build daemon disappeared unexpectedly (it may have been killed or may have crashed)
```

The publish step inherited the 64g heap settings from gradle.properties, which the 7 GB runner cannot satisfy, so the OS killed the Gradle daemon mid-build. Cap the heap at 6g and run without daemons and with a single worker.