### PR TITLE
Reduce gradle and daemon excessive memory limits

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 #Gradle
-org.gradle.jvmargs=-Xmx64g -XX:MaxMetaspaceSize=8g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.workers.max=2
 #Kotlin
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Xmx32g -XX:+UseG1GC
+kotlin.daemon.jvmargs=-Xmx4g -XX:+UseG1GC
 #MPP
 kotlin.mpp.enableCInteropCommonization=true
 #Android


### PR DESCRIPTION
I've measured it during a local clean build: the Gradle daemon's metaspace peaked at ~400 MB against the 1 GB cap while compiling the R4 model, and heap peaked at ~5.3 GB against the 8 GB cap. 

CI is also green across all targets with these settings, and if we ever did hit the cap it fails fast with OutOfMemoryError: Metaspace rather than degrading, so it would be a one-line bump.

| Process | Limit | Peak metaspace used | Peak heap used |
|---|---|---|---|
| Gradle daemon | 1g metaspace, 8g heap | 402 MB (39% of cap) | 5.3 GB (67% of cap) |