### PR TITLE
Fix compiler warnings in generated code

### DIFF
--- a/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/EnumTypeSpecGenerator.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/EnumTypeSpecGenerator.kt
@@ -118,7 +118,11 @@ object EnumTypeSpecGenerator {
                   .returns(ClassName.bestGuess(enumClassName))
                   .beginControlFlow("return when (code)")
                   .apply {
-                    fhirEnum.constants.forEach { addStatement("%S -> %L", it.code, it.name) }
+                    fhirEnum.constants
+                      .distinctBy { it.code }
+                      .forEach {
+                        addStatement("%S -> %L", it.code, it.name)
+                      }
                     addStatement(
                       "else -> throw IllegalArgumentException(\"Unknown code \$code for enum %L\")",
                       enumClassName,

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/FhirResourcePolymorphicSerializerFileSpecGenerator.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/FhirResourcePolymorphicSerializerFileSpecGenerator.kt
@@ -223,7 +223,8 @@ object FhirResourcePolymorphicSerializerFileSpecGenerator {
       .addAnnotation(
         AnnotationSpec.builder(Suppress::class)
           .useSiteTarget(AnnotationSpec.UseSiteTarget.FILE)
-          .addMember("%S, %S", "INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+          .addMember("%S", "INVISIBLE_MEMBER")
+          .addMember("%S", "INVISIBLE_REFERENCE")
           .build()
       )
       .addType(objectSpec)

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/SearchParamFileSpecGenerator.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/SearchParamFileSpecGenerator.kt
@@ -131,7 +131,7 @@ object SearchParamFileSpecGenerator {
 
     val extractFn =
       FunSpec.builder("extract")
-        .addModifiers(KModifier.PUBLIC, KModifier.INLINE)
+        .addModifiers(KModifier.PUBLIC)
         .addKdoc(
           "Extracts the values for [param] from this resource. Equivalent to " +
             "`param.extractFrom(this)`, but reads more fluently at the call site " +

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/searchparam/SearchParamExtractFromFunctionBodyEmitter.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/searchparam/SearchParamExtractFromFunctionBodyEmitter.kt
@@ -57,7 +57,13 @@ internal object SearchParamExtractFromFunctionBodyEmitter {
           ),
         )
       is SearchParamPattern.WhereFilter ->
-        forWhereFilter(pattern.resolved, pattern.field, pattern.value, pattern.postPath)
+        forWhereFilter(
+          pattern.resolved,
+          pattern.field,
+          pattern.value,
+          pattern.postPath,
+          pattern.isFieldNullable,
+        )
       SearchParamPattern.Unsupported ->
         CodeBlock.of(
           "throw %T(%S)",
@@ -97,12 +103,16 @@ internal object SearchParamExtractFromFunctionBodyEmitter {
     field: String,
     value: String,
     postPath: ResolvedExpression?,
+    isFieldNullable: Boolean,
   ): CodeBlock {
+    val fieldAccess =
+      if (isFieldNullable) CodeBlock.of("it.%N?.value?.toString()", field)
+      else CodeBlock.of("it.%N.value?.toString()", field)
     val filtered =
       CodeBlock.of(
-        "%L.filter { it.%N?.value?.toString() == %S }",
+        "%L.filter { %L == %S }",
         filterBase(resolved.segments),
-        field,
+        fieldAccess,
         value,
       )
     var state: PathExpr = PathExpr.Listed(filtered)
@@ -118,7 +128,7 @@ internal object SearchParamExtractFromFunctionBodyEmitter {
    */
   private fun forWhereResolve(resolved: ResolvedExpression, targetType: String): CodeBlock =
     CodeBlock.of(
-      "%L.filter { it.reference?.value?.toString()?.contains(%S) == true }",
+      "%L.filter { it.reference?.value?.contains(%S) == true }",
       filterBase(resolved.segments),
       "$targetType/",
     )

--- a/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/searchparam/SearchParamPattern.kt
+++ b/fhir-codegen/gradle-plugin/src/main/kotlin/dev/ohs/fhir/codegen/searchparam/SearchParamPattern.kt
@@ -58,6 +58,7 @@ internal sealed interface SearchParamPattern {
     val field: String,
     val value: String,
     val postPath: ResolvedExpression?,
+    val isFieldNullable: Boolean = true,
   ) : SearchParamPattern
 
   /** Anything not matched by the parsers above. Renders as `List<Any>` / `return emptyList()`. */
@@ -93,19 +94,29 @@ internal fun parseSearchParamExpression(
   }
 
   parseWhereExpression(expression)?.let { w ->
-    if (w.isResolveFilter) {
-      resolver.resolve(w.pathBeforeWhere, resourceName)?.let {
-        return SearchParamPattern.WhereResolve(it, w.resolveTargetType!!)
-      }
-    } else {
-      val resolved = resolver.resolve(w.pathBeforeWhere, resourceName)
-      val elementType = resolved?.segments?.lastOrNull()?.leafTypeCode
-      if (resolved != null && elementType != null) {
-        val postPath =
-          if (w.pathAfterWhere != null) {
-            resolver.resolve("$elementType.${w.pathAfterWhere}", elementType) ?: return@let
-          } else null
-        return SearchParamPattern.WhereFilter(resolved, w.filterField!!, w.filterValue!!, postPath)
+    when (w) {
+      is WhereParseResult.Resolve ->
+        resolver.resolve(w.pathBeforeWhere, resourceName)?.let {
+          return SearchParamPattern.WhereResolve(it, w.resolveTargetType)
+        }
+      is WhereParseResult.Filter -> {
+        val resolved = resolver.resolve(w.pathBeforeWhere, resourceName)
+        val elementType = resolved?.segments?.lastOrNull()?.leafTypeCode
+        if (resolved != null && elementType != null) {
+          val postPath =
+            if (w.pathAfterWhere != null) {
+              resolver.resolve("$elementType.${w.pathAfterWhere}", elementType) ?: return@let
+            } else null
+          val fieldSegment =
+            resolver.resolve("$elementType.${w.filterField}", elementType)?.segments?.lastOrNull()
+          return SearchParamPattern.WhereFilter(
+            resolved,
+            w.filterField,
+            w.filterValue,
+            postPath,
+            isFieldNullable = fieldSegment?.isNullable ?: true,
+          )
+        }
       }
     }
   }
@@ -124,34 +135,35 @@ private fun parseElementCastExpression(expression: String): Pair<String, String>
   return null
 }
 
-private data class WhereParseResult(
-  val pathBeforeWhere: String,
-  val isResolveFilter: Boolean,
-  val resolveTargetType: String?,
-  val filterField: String?,
-  val filterValue: String?,
-  val pathAfterWhere: String?,
-)
+private sealed interface WhereParseResult {
+  val pathBeforeWhere: String
+
+  data class Resolve(
+    override val pathBeforeWhere: String,
+    val resolveTargetType: String,
+  ) : WhereParseResult
+
+  data class Filter(
+    override val pathBeforeWhere: String,
+    val filterField: String,
+    val filterValue: String,
+    val pathAfterWhere: String?,
+  ) : WhereParseResult
+}
 
 private fun parseWhereExpression(expression: String): WhereParseResult? {
   val trimmed = expression.trim()
 
   Regex("""(.+)\.where\(resolve\(\)\s+is\s+(\w+)\)""").matchEntire(trimmed)?.let {
-    return WhereParseResult(
+    return WhereParseResult.Resolve(
       pathBeforeWhere = it.groupValues[1],
-      isResolveFilter = true,
       resolveTargetType = it.groupValues[2],
-      filterField = null,
-      filterValue = null,
-      pathAfterWhere = null,
     )
   }
 
   Regex("""(.+)\.where\((\w+)='([^']+)'\)(?:\.(.+))?""").matchEntire(trimmed)?.let {
-    return WhereParseResult(
+    return WhereParseResult.Filter(
       pathBeforeWhere = it.groupValues[1],
-      isResolveFilter = false,
-      resolveTargetType = null,
       filterField = it.groupValues[2],
       filterValue = it.groupValues[3],
       pathAfterWhere = it.groupValues[4].ifEmpty { null },

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/ResourcePolymorphicSerializer.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/ResourcePolymorphicSerializer.kt
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+@file:Suppress(
+  "INVISIBLE_MEMBER",
+  "INVISIBLE_REFERENCE",
+)
 
 package dev.ohs.fhir.model.r4
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AccountSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AccountSearchParams.kt
@@ -73,7 +73,7 @@ public object AccountSearchParams {
       expression = "Account.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ActivityDefinitionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ActivityDefinitionSearchParams.kt
@@ -339,7 +339,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AppointmentResponseSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AppointmentResponseSearchParams.kt
@@ -81,9 +81,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Location)",
       target = listOf(Location::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Location/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Location/") == true }
       },
     )
 
@@ -102,9 +100,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -116,7 +112,7 @@ public object AppointmentResponseSearchParams {
       target = listOf(Practitioner::class),
       extractor = { resource ->
         listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Practitioner/") == true
+          it.reference?.value?.contains("Practitioner/") == true
         }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AppointmentSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AppointmentSearchParams.kt
@@ -237,7 +237,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Location/") == true }
+          .filter { it.reference?.value?.contains("Location/") == true }
       },
     )
 
@@ -258,7 +258,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+          .filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -271,7 +271,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AuditEventSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/AuditEventSearchParams.kt
@@ -443,7 +443,7 @@ public object AuditEventSearchParams {
       extractor = { resource ->
         resource.agent
           .mapNotNull { it.who }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+          .filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/BasicSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/BasicSearchParams.kt
@@ -223,9 +223,7 @@ public object BasicSearchParams {
       expression = "Basic.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CarePlanSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CarePlanSearchParams.kt
@@ -216,9 +216,7 @@ public object CarePlanSearchParams {
       expression = "CarePlan.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CareTeamSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CareTeamSearchParams.kt
@@ -97,9 +97,7 @@ public object CareTeamSearchParams {
       expression = "CareTeam.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ChargeItemSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ChargeItemSearchParams.kt
@@ -136,9 +136,7 @@ public object ChargeItemSearchParams {
       expression = "ChargeItem.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ClinicalImpressionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ClinicalImpressionSearchParams.kt
@@ -253,9 +253,7 @@ public object ClinicalImpressionSearchParams {
       expression = "ClinicalImpression.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CommunicationRequestSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CommunicationRequestSearchParams.kt
@@ -399,9 +399,7 @@ public object CommunicationRequestSearchParams {
       expression = "CommunicationRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CommunicationSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CommunicationSearchParams.kt
@@ -555,9 +555,7 @@ public object CommunicationSearchParams {
       expression = "Communication.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CompositionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/CompositionSearchParams.kt
@@ -424,9 +424,7 @@ public object CompositionSearchParams {
       expression = "Composition.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ConditionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ConditionSearchParams.kt
@@ -464,9 +464,7 @@ public object ConditionSearchParams {
       expression = "Condition.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ContractSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ContractSearchParams.kt
@@ -226,7 +226,7 @@ public object ContractSearchParams {
       expression = "Contract.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DeviceRequestSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DeviceRequestSearchParams.kt
@@ -440,9 +440,7 @@ public object DeviceRequestSearchParams {
       expression = "DeviceRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DiagnosticReportSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DiagnosticReportSearchParams.kt
@@ -154,9 +154,7 @@ public object DiagnosticReportSearchParams {
       expression = "DiagnosticReport.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DocumentManifestSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DocumentManifestSearchParams.kt
@@ -383,9 +383,7 @@ public object DocumentManifestSearchParams {
       expression = "DocumentManifest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DocumentReferenceSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/DocumentReferenceSearchParams.kt
@@ -314,9 +314,7 @@ public object DocumentReferenceSearchParams {
       expression = "DocumentReference.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EncounterSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EncounterSearchParams.kt
@@ -177,9 +177,7 @@ public object EncounterSearchParams {
       expression = "Encounter.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -192,7 +190,7 @@ public object EncounterSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.individual }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EpisodeOfCareSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EpisodeOfCareSearchParams.kt
@@ -47,7 +47,7 @@ public object EpisodeOfCareSearchParams {
       target = listOf(Practitioner::class),
       extractor = { resource ->
         listOfNotNull(resource.careManager).filter {
-          it.reference?.value?.toString()?.contains("Practitioner/") == true
+          it.reference?.value?.contains("Practitioner/") == true
         }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EventDefinitionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EventDefinitionSearchParams.kt
@@ -339,7 +339,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EvidenceSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EvidenceSearchParams.kt
@@ -339,7 +339,7 @@ public object EvidenceSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object EvidenceSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object EvidenceSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object EvidenceSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object EvidenceSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EvidenceVariableSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/EvidenceVariableSearchParams.kt
@@ -339,7 +339,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/FlagSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/FlagSearchParams.kt
@@ -91,9 +91,7 @@ public object FlagSearchParams {
       expression = "Flag.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/GoalSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/GoalSearchParams.kt
@@ -75,9 +75,7 @@ public object GoalSearchParams {
       expression = "Goal.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/GuidanceResponseSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/GuidanceResponseSearchParams.kt
@@ -47,9 +47,7 @@ public object GuidanceResponseSearchParams {
       expression = "GuidanceResponse.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ImagingStudySearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ImagingStudySearchParams.kt
@@ -140,9 +140,7 @@ public object ImagingStudySearchParams {
       expression = "ImagingStudy.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/InvoiceSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/InvoiceSearchParams.kt
@@ -108,9 +108,7 @@ public object InvoiceSearchParams {
       expression = "Invoice.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/LibrarySearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/LibrarySearchParams.kt
@@ -339,7 +339,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -561,7 +561,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -721,7 +721,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -921,7 +921,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1097,7 +1097,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ListSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ListSearchParams.kt
@@ -391,9 +391,7 @@ public object ListSearchParams {
       expression = "List.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MeasureReportSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MeasureReportSearchParams.kt
@@ -366,9 +366,7 @@ public object MeasureReportSearchParams {
       expression = "MeasureReport.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MeasureSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MeasureSearchParams.kt
@@ -339,7 +339,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MediaSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MediaSearchParams.kt
@@ -122,9 +122,7 @@ public object MediaSearchParams {
       expression = "Media.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationAdministrationSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationAdministrationSearchParams.kt
@@ -109,9 +109,7 @@ public object MedicationAdministrationSearchParams {
       expression = "MedicationAdministration.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationDispenseSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationDispenseSearchParams.kt
@@ -101,9 +101,7 @@ public object MedicationDispenseSearchParams {
       expression = "MedicationDispense.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationRequestSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationRequestSearchParams.kt
@@ -157,9 +157,7 @@ public object MedicationRequestSearchParams {
       expression = "MedicationRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationStatementSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/MedicationStatementSearchParams.kt
@@ -124,9 +124,7 @@ public object MedicationStatementSearchParams {
       expression = "MedicationStatement.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ObservationSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ObservationSearchParams.kt
@@ -690,9 +690,7 @@ public object ObservationSearchParams {
       expression = "Observation.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/PersonSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/PersonSearchParams.kt
@@ -155,9 +155,7 @@ public object PersonSearchParams {
       expression = "Person.link.target.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.link
-          .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.link.map { it.target }.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -188,7 +186,7 @@ public object PersonSearchParams {
       extractor = { resource ->
         resource.link
           .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 
@@ -201,7 +199,7 @@ public object PersonSearchParams {
       extractor = { resource ->
         resource.link
           .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("RelatedPerson/") == true }
+          .filter { it.reference?.value?.contains("RelatedPerson/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/PlanDefinitionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/PlanDefinitionSearchParams.kt
@@ -339,7 +339,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -562,7 +562,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -722,7 +722,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -922,7 +922,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1098,7 +1098,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ProcedureSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ProcedureSearchParams.kt
@@ -155,9 +155,7 @@ public object ProcedureSearchParams {
       expression = "Procedure.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ProvenanceSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ProvenanceSearchParams.kt
@@ -382,7 +382,7 @@ public object ProvenanceSearchParams {
       expression = "Provenance.target.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.target.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.target.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/QuestionnaireResponseSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/QuestionnaireResponseSearchParams.kt
@@ -258,9 +258,7 @@ public object QuestionnaireResponseSearchParams {
       expression = "QuestionnaireResponse.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/RequestGroupSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/RequestGroupSearchParams.kt
@@ -139,9 +139,7 @@ public object RequestGroupSearchParams {
       expression = "RequestGroup.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ResearchDefinitionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ResearchDefinitionSearchParams.kt
@@ -339,7 +339,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ResearchElementDefinitionSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ResearchElementDefinitionSearchParams.kt
@@ -339,7 +339,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -553,7 +553,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -713,7 +713,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -913,7 +913,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1089,7 +1089,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/RiskAssessmentSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/RiskAssessmentSearchParams.kt
@@ -91,9 +91,7 @@ public object RiskAssessmentSearchParams {
       expression = "RiskAssessment.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/SearchParam.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/SearchParam.kt
@@ -45,5 +45,5 @@ public class SearchParam<R : Resource, T>(
  * Extracts the values for [param] from this resource. Equivalent to `param.extractFrom(this)`, but
  * reads more fluently at the call site (e.g. `patient.extract(PatientSearchParams.birthdate)`).
  */
-public inline fun <R : Resource, T> R.extract(`param`: SearchParam<R, T>): List<T> =
+public fun <R : Resource, T> R.extract(`param`: SearchParam<R, T>): List<T> =
   param.extractFrom(this)

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ServiceRequestSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/ServiceRequestSearchParams.kt
@@ -150,9 +150,7 @@ public object ServiceRequestSearchParams {
       expression = "ServiceRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class, Group::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/SpecimenSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/SpecimenSearchParams.kt
@@ -112,9 +112,7 @@ public object SpecimenSearchParams {
       expression = "Specimen.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/TaskSearchParams.kt
+++ b/fhir-model-r4/src/commonMain/kotlin/dev/ohs/fhir/model/r4/search/TaskSearchParams.kt
@@ -590,9 +590,7 @@ public object TaskSearchParams {
       expression = "Task.for.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.`for`).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.`for`).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/ResourcePolymorphicSerializer.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/ResourcePolymorphicSerializer.kt
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+@file:Suppress(
+  "INVISIBLE_MEMBER",
+  "INVISIBLE_REFERENCE",
+)
 
 package dev.ohs.fhir.model.r4b
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AccountSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AccountSearchParams.kt
@@ -73,7 +73,7 @@ public object AccountSearchParams {
       expression = "Account.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ActivityDefinitionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ActivityDefinitionSearchParams.kt
@@ -329,7 +329,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -538,7 +538,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -693,7 +693,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -888,7 +888,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1059,7 +1059,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AppointmentResponseSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AppointmentResponseSearchParams.kt
@@ -81,9 +81,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Location)",
       target = listOf(Location::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Location/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Location/") == true }
       },
     )
 
@@ -102,9 +100,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -116,7 +112,7 @@ public object AppointmentResponseSearchParams {
       target = listOf(Practitioner::class),
       extractor = { resource ->
         listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Practitioner/") == true
+          it.reference?.value?.contains("Practitioner/") == true
         }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AppointmentSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AppointmentSearchParams.kt
@@ -232,7 +232,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Location/") == true }
+          .filter { it.reference?.value?.contains("Location/") == true }
       },
     )
 
@@ -253,7 +253,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+          .filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -266,7 +266,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AuditEventSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/AuditEventSearchParams.kt
@@ -433,7 +433,7 @@ public object AuditEventSearchParams {
       extractor = { resource ->
         resource.agent
           .mapNotNull { it.who }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+          .filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/BasicSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/BasicSearchParams.kt
@@ -218,9 +218,7 @@ public object BasicSearchParams {
       expression = "Basic.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CarePlanSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CarePlanSearchParams.kt
@@ -216,9 +216,7 @@ public object CarePlanSearchParams {
       expression = "CarePlan.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CareTeamSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CareTeamSearchParams.kt
@@ -97,9 +97,7 @@ public object CareTeamSearchParams {
       expression = "CareTeam.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ChargeItemSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ChargeItemSearchParams.kt
@@ -136,9 +136,7 @@ public object ChargeItemSearchParams {
       expression = "ChargeItem.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ClinicalImpressionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ClinicalImpressionSearchParams.kt
@@ -248,9 +248,7 @@ public object ClinicalImpressionSearchParams {
       expression = "ClinicalImpression.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ClinicalUseDefinitionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ClinicalUseDefinitionSearchParams.kt
@@ -112,7 +112,7 @@ public object ClinicalUseDefinitionSearchParams {
       target = listOf(MedicinalProductDefinition::class),
       extractor = { resource ->
         resource.subject.filter {
-          it.reference?.value?.toString()?.contains("MedicinalProductDefinition/") == true
+          it.reference?.value?.contains("MedicinalProductDefinition/") == true
         }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CommunicationRequestSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CommunicationRequestSearchParams.kt
@@ -389,9 +389,7 @@ public object CommunicationRequestSearchParams {
       expression = "CommunicationRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CommunicationSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CommunicationSearchParams.kt
@@ -540,9 +540,7 @@ public object CommunicationSearchParams {
       expression = "Communication.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CompositionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/CompositionSearchParams.kt
@@ -414,9 +414,7 @@ public object CompositionSearchParams {
       expression = "Composition.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ConditionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ConditionSearchParams.kt
@@ -454,9 +454,7 @@ public object ConditionSearchParams {
       expression = "Condition.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ContractSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ContractSearchParams.kt
@@ -221,7 +221,7 @@ public object ContractSearchParams {
       expression = "Contract.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DeviceRequestSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DeviceRequestSearchParams.kt
@@ -430,9 +430,7 @@ public object DeviceRequestSearchParams {
       expression = "DeviceRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DeviceUseStatementSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DeviceUseStatementSearchParams.kt
@@ -57,9 +57,7 @@ public object DeviceUseStatementSearchParams {
       expression = "DeviceUseStatement.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DiagnosticReportSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DiagnosticReportSearchParams.kt
@@ -156,9 +156,7 @@ public object DiagnosticReportSearchParams {
       expression = "DiagnosticReport.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DocumentManifestSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DocumentManifestSearchParams.kt
@@ -373,9 +373,7 @@ public object DocumentManifestSearchParams {
       expression = "DocumentManifest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DocumentReferenceSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/DocumentReferenceSearchParams.kt
@@ -253,7 +253,7 @@ public object DocumentReferenceSearchParams {
       target = listOf(Encounter::class),
       extractor = { resource ->
         (resource.context?.encounter ?: emptyList()).filter {
-          it.reference?.value?.toString()?.contains("Encounter/") == true
+          it.reference?.value?.contains("Encounter/") == true
         }
       },
     )
@@ -313,9 +313,7 @@ public object DocumentReferenceSearchParams {
       expression = "DocumentReference.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/EncounterSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/EncounterSearchParams.kt
@@ -177,9 +177,7 @@ public object EncounterSearchParams {
       expression = "Encounter.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -192,7 +190,7 @@ public object EncounterSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.individual }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/EpisodeOfCareSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/EpisodeOfCareSearchParams.kt
@@ -46,7 +46,7 @@ public object EpisodeOfCareSearchParams {
       target = listOf(Practitioner::class),
       extractor = { resource ->
         listOfNotNull(resource.careManager).filter {
-          it.reference?.value?.toString()?.contains("Practitioner/") == true
+          it.reference?.value?.contains("Practitioner/") == true
         }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/EventDefinitionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/EventDefinitionSearchParams.kt
@@ -329,7 +329,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -538,7 +538,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -693,7 +693,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -888,7 +888,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1059,7 +1059,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/FlagSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/FlagSearchParams.kt
@@ -90,9 +90,7 @@ public object FlagSearchParams {
       expression = "Flag.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/GoalSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/GoalSearchParams.kt
@@ -75,9 +75,7 @@ public object GoalSearchParams {
       expression = "Goal.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/GuidanceResponseSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/GuidanceResponseSearchParams.kt
@@ -47,9 +47,7 @@ public object GuidanceResponseSearchParams {
       expression = "GuidanceResponse.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ImagingStudySearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ImagingStudySearchParams.kt
@@ -140,9 +140,7 @@ public object ImagingStudySearchParams {
       expression = "ImagingStudy.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/InvoiceSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/InvoiceSearchParams.kt
@@ -108,9 +108,7 @@ public object InvoiceSearchParams {
       expression = "Invoice.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/LibrarySearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/LibrarySearchParams.kt
@@ -329,7 +329,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -546,7 +546,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -701,7 +701,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -896,7 +896,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1067,7 +1067,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ListSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ListSearchParams.kt
@@ -381,9 +381,7 @@ public object ListSearchParams {
       expression = "List.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MeasureReportSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MeasureReportSearchParams.kt
@@ -356,9 +356,7 @@ public object MeasureReportSearchParams {
       expression = "MeasureReport.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MeasureSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MeasureSearchParams.kt
@@ -329,7 +329,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -538,7 +538,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -693,7 +693,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -888,7 +888,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1059,7 +1059,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MediaSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MediaSearchParams.kt
@@ -122,9 +122,7 @@ public object MediaSearchParams {
       expression = "Media.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationAdministrationSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationAdministrationSearchParams.kt
@@ -109,9 +109,7 @@ public object MedicationAdministrationSearchParams {
       expression = "MedicationAdministration.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationDispenseSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationDispenseSearchParams.kt
@@ -101,9 +101,7 @@ public object MedicationDispenseSearchParams {
       expression = "MedicationDispense.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationRequestSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationRequestSearchParams.kt
@@ -157,9 +157,7 @@ public object MedicationRequestSearchParams {
       expression = "MedicationRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationStatementSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/MedicationStatementSearchParams.kt
@@ -124,9 +124,7 @@ public object MedicationStatementSearchParams {
       expression = "MedicationStatement.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ObservationSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ObservationSearchParams.kt
@@ -680,9 +680,7 @@ public object ObservationSearchParams {
       expression = "Observation.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/PersonSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/PersonSearchParams.kt
@@ -155,9 +155,7 @@ public object PersonSearchParams {
       expression = "Person.link.target.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.link
-          .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.link.map { it.target }.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -188,7 +186,7 @@ public object PersonSearchParams {
       extractor = { resource ->
         resource.link
           .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 
@@ -201,7 +199,7 @@ public object PersonSearchParams {
       extractor = { resource ->
         resource.link
           .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("RelatedPerson/") == true }
+          .filter { it.reference?.value?.contains("RelatedPerson/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/PlanDefinitionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/PlanDefinitionSearchParams.kt
@@ -329,7 +329,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -547,7 +547,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -702,7 +702,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -897,7 +897,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1068,7 +1068,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ProcedureSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ProcedureSearchParams.kt
@@ -154,9 +154,7 @@ public object ProcedureSearchParams {
       expression = "Procedure.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ProvenanceSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ProvenanceSearchParams.kt
@@ -372,7 +372,7 @@ public object ProvenanceSearchParams {
       expression = "Provenance.target.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.target.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.target.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/QuestionnaireResponseSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/QuestionnaireResponseSearchParams.kt
@@ -253,9 +253,7 @@ public object QuestionnaireResponseSearchParams {
       expression = "QuestionnaireResponse.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/RequestGroupSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/RequestGroupSearchParams.kt
@@ -139,9 +139,7 @@ public object RequestGroupSearchParams {
       expression = "RequestGroup.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ResearchDefinitionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ResearchDefinitionSearchParams.kt
@@ -329,7 +329,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -538,7 +538,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -693,7 +693,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -888,7 +888,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1059,7 +1059,7 @@ public object ResearchDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ResearchElementDefinitionSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ResearchElementDefinitionSearchParams.kt
@@ -329,7 +329,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -538,7 +538,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -693,7 +693,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -888,7 +888,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1059,7 +1059,7 @@ public object ResearchElementDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/RiskAssessmentSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/RiskAssessmentSearchParams.kt
@@ -90,9 +90,7 @@ public object RiskAssessmentSearchParams {
       expression = "RiskAssessment.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/SearchParam.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/SearchParam.kt
@@ -45,5 +45,5 @@ public class SearchParam<R : Resource, T>(
  * Extracts the values for [param] from this resource. Equivalent to `param.extractFrom(this)`, but
  * reads more fluently at the call site (e.g. `patient.extract(PatientSearchParams.birthdate)`).
  */
-public inline fun <R : Resource, T> R.extract(`param`: SearchParam<R, T>): List<T> =
+public fun <R : Resource, T> R.extract(`param`: SearchParam<R, T>): List<T> =
   param.extractFrom(this)

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ServiceRequestSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/ServiceRequestSearchParams.kt
@@ -149,9 +149,7 @@ public object ServiceRequestSearchParams {
       expression = "ServiceRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/SpecimenSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/SpecimenSearchParams.kt
@@ -112,9 +112,7 @@ public object SpecimenSearchParams {
       expression = "Specimen.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/TaskSearchParams.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/search/TaskSearchParams.kt
@@ -575,9 +575,7 @@ public object TaskSearchParams {
       expression = "Task.for.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.`for`).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.`for`).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/terminologies/AllSecurityLabels.kt
+++ b/fhir-model-r4b/src/commonMain/kotlin/dev/ohs/fhir/model/r4b/terminologies/AllSecurityLabels.kt
@@ -1996,7 +1996,6 @@ public enum class AllSecurityLabels(
         "ECH" -> Ech
         "FLY" -> Fly
         "IND" -> Ind
-        "SSP" -> Ssp
         "_CoverageItemLimitObservationValue" -> _CoverageItemLimitObservationValue
         "_CoverageLocationLimitObservationValue" -> _CoverageLocationLimitObservationValue
         "_CriticalityObservationValue" -> _CriticalityObservationValue
@@ -2042,7 +2041,6 @@ public enum class AllSecurityLabels(
         "LE" -> Le
         "ME" -> Me
         "MI" -> Mi
-        "N" -> N
         "S" -> S
         "_SecurityObservationValue" -> _SecurityObservationValue
         "_SECCATOBV" -> _Seccatobv
@@ -2098,8 +2096,6 @@ public enum class AllSecurityLabels(
         "TRSTMECOBV" -> Trstmecobv
         "_SeverityObservation" -> _SeverityObservation
         "H" -> H
-        "L" -> L
-        "M" -> M
         "_SubjectBodyPosition" -> _SubjectBodyPosition
         "LLD" -> Lld
         "PRN" -> Prn

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/ResourcePolymorphicSerializer.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/ResourcePolymorphicSerializer.kt
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+@file:Suppress(
+  "INVISIBLE_MEMBER",
+  "INVISIBLE_REFERENCE",
+)
 
 package dev.ohs.fhir.model.r5
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AccountSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AccountSearchParams.kt
@@ -83,7 +83,7 @@ public object AccountSearchParams {
       expression = "Account.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ActivityDefinitionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ActivityDefinitionSearchParams.kt
@@ -365,7 +365,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -594,7 +594,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -767,7 +767,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -988,7 +988,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1177,7 +1177,7 @@ public object ActivityDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AdverseEventSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AdverseEventSearchParams.kt
@@ -111,9 +111,7 @@ public object AdverseEventSearchParams {
       expression = "AdverseEvent.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AppointmentResponseSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AppointmentResponseSearchParams.kt
@@ -75,9 +75,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Group)",
       target = listOf(Group::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Group/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Group/") == true }
       },
     )
 
@@ -96,9 +94,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Location)",
       target = listOf(Location::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Location/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Location/") == true }
       },
     )
 
@@ -117,9 +113,7 @@ public object AppointmentResponseSearchParams {
       expression = "AppointmentResponse.actor.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.actor).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -131,7 +125,7 @@ public object AppointmentResponseSearchParams {
       target = listOf(Practitioner::class),
       extractor = { resource ->
         listOfNotNull(resource.actor).filter {
-          it.reference?.value?.toString()?.contains("Practitioner/") == true
+          it.reference?.value?.contains("Practitioner/") == true
         }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AppointmentSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/AppointmentSearchParams.kt
@@ -255,7 +255,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Group/") == true }
+          .filter { it.reference?.value?.contains("Group/") == true }
       },
     )
 
@@ -276,7 +276,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Location/") == true }
+          .filter { it.reference?.value?.contains("Location/") == true }
       },
     )
 
@@ -297,7 +297,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+          .filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -310,7 +310,7 @@ public object AppointmentSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/BasicSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/BasicSearchParams.kt
@@ -238,9 +238,7 @@ public object BasicSearchParams {
       expression = "Basic.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CarePlanSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CarePlanSearchParams.kt
@@ -225,9 +225,7 @@ public object CarePlanSearchParams {
       expression = "CarePlan.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CareTeamSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CareTeamSearchParams.kt
@@ -101,9 +101,7 @@ public object CareTeamSearchParams {
       expression = "CareTeam.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ChargeItemSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ChargeItemSearchParams.kt
@@ -144,9 +144,7 @@ public object ChargeItemSearchParams {
       expression = "ChargeItem.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ClinicalImpressionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ClinicalImpressionSearchParams.kt
@@ -241,9 +241,7 @@ public object ClinicalImpressionSearchParams {
       expression = "ClinicalImpression.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ClinicalUseDefinitionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ClinicalUseDefinitionSearchParams.kt
@@ -129,7 +129,7 @@ public object ClinicalUseDefinitionSearchParams {
       target = listOf(MedicinalProductDefinition::class),
       extractor = { resource ->
         resource.subject.filter {
-          it.reference?.value?.toString()?.contains("MedicinalProductDefinition/") == true
+          it.reference?.value?.contains("MedicinalProductDefinition/") == true
         }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CodeSystemSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CodeSystemSearchParams.kt
@@ -437,7 +437,7 @@ public object CodeSystemSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -660,7 +660,7 @@ public object CodeSystemSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CommunicationRequestSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CommunicationRequestSearchParams.kt
@@ -447,9 +447,7 @@ public object CommunicationRequestSearchParams {
       expression = "CommunicationRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CommunicationSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CommunicationSearchParams.kt
@@ -594,9 +594,7 @@ public object CommunicationSearchParams {
       expression = "Communication.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CompositionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/CompositionSearchParams.kt
@@ -613,7 +613,7 @@ public object CompositionSearchParams {
       expression = "Composition.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ConceptMapSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ConceptMapSearchParams.kt
@@ -421,7 +421,7 @@ public object ConceptMapSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -653,7 +653,7 @@ public object ConceptMapSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ConditionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ConditionSearchParams.kt
@@ -522,9 +522,7 @@ public object ConditionSearchParams {
       expression = "Condition.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ConsentSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ConsentSearchParams.kt
@@ -461,9 +461,7 @@ public object ConsentSearchParams {
       expression = "Consent.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ContractSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ContractSearchParams.kt
@@ -239,7 +239,7 @@ public object ContractSearchParams {
       expression = "Contract.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DetectedIssueSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DetectedIssueSearchParams.kt
@@ -418,9 +418,7 @@ public object DetectedIssueSearchParams {
       expression = "DetectedIssue.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DeviceAssociationSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DeviceAssociationSearchParams.kt
@@ -68,9 +68,7 @@ public object DeviceAssociationSearchParams {
       expression = "DeviceAssociation.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -89,9 +87,7 @@ public object DeviceAssociationSearchParams {
       expression = "DeviceAssociation.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DeviceDispenseSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DeviceDispenseSearchParams.kt
@@ -57,9 +57,7 @@ public object DeviceDispenseSearchParams {
       expression = "DeviceDispense.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DeviceRequestSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DeviceRequestSearchParams.kt
@@ -465,9 +465,7 @@ public object DeviceRequestSearchParams {
       expression = "DeviceRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DiagnosticReportSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DiagnosticReportSearchParams.kt
@@ -149,9 +149,7 @@ public object DiagnosticReportSearchParams {
       expression = "DiagnosticReport.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DocumentReferenceSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/DocumentReferenceSearchParams.kt
@@ -643,9 +643,7 @@ public object DocumentReferenceSearchParams {
       expression = "DocumentReference.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EncounterHistorySearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EncounterHistorySearchParams.kt
@@ -58,9 +58,7 @@ public object EncounterHistorySearchParams {
       expression = "EncounterHistory.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EncounterSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EncounterSearchParams.kt
@@ -236,9 +236,7 @@ public object EncounterSearchParams {
       expression = "Encounter.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -251,7 +249,7 @@ public object EncounterSearchParams {
       extractor = { resource ->
         resource.participant
           .mapNotNull { it.actor }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EpisodeOfCareSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EpisodeOfCareSearchParams.kt
@@ -49,7 +49,7 @@ public object EpisodeOfCareSearchParams {
       target = listOf(Practitioner::class),
       extractor = { resource ->
         listOfNotNull(resource.careManager).filter {
-          it.reference?.value?.toString()?.contains("Practitioner/") == true
+          it.reference?.value?.contains("Practitioner/") == true
         }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EventDefinitionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EventDefinitionSearchParams.kt
@@ -365,7 +365,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -594,7 +594,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -767,7 +767,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -980,7 +980,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1169,7 +1169,7 @@ public object EventDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EvidenceVariableSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/EvidenceVariableSearchParams.kt
@@ -363,7 +363,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -592,7 +592,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -765,7 +765,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -962,7 +962,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1151,7 +1151,7 @@ public object EvidenceVariableSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/FlagSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/FlagSearchParams.kt
@@ -102,9 +102,7 @@ public object FlagSearchParams {
       expression = "Flag.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/GenomicStudySearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/GenomicStudySearchParams.kt
@@ -372,9 +372,7 @@ public object GenomicStudySearchParams {
       expression = "GenomicStudy.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/GoalSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/GoalSearchParams.kt
@@ -110,9 +110,7 @@ public object GoalSearchParams {
       expression = "Goal.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/GuidanceResponseSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/GuidanceResponseSearchParams.kt
@@ -48,9 +48,7 @@ public object GuidanceResponseSearchParams {
       expression = "GuidanceResponse.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ImagingSelectionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ImagingSelectionSearchParams.kt
@@ -125,9 +125,7 @@ public object ImagingSelectionSearchParams {
       expression = "ImagingSelection.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ImagingStudySearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ImagingStudySearchParams.kt
@@ -147,9 +147,7 @@ public object ImagingStudySearchParams {
       expression = "ImagingStudy.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/InvoiceSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/InvoiceSearchParams.kt
@@ -108,9 +108,7 @@ public object InvoiceSearchParams {
       expression = "Invoice.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/LibrarySearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/LibrarySearchParams.kt
@@ -365,7 +365,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -602,7 +602,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -775,7 +775,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -988,7 +988,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1177,7 +1177,7 @@ public object LibrarySearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ListSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ListSearchParams.kt
@@ -417,7 +417,7 @@ public object ListSearchParams {
       expression = "List.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.subject.filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.subject.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MeasureReportSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MeasureReportSearchParams.kt
@@ -401,9 +401,7 @@ public object MeasureReportSearchParams {
       expression = "MeasureReport.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MeasureSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MeasureSearchParams.kt
@@ -365,7 +365,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -594,7 +594,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -767,7 +767,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -980,7 +980,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1169,7 +1169,7 @@ public object MeasureSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationAdministrationSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationAdministrationSearchParams.kt
@@ -107,9 +107,7 @@ public object MedicationAdministrationSearchParams {
       expression = "MedicationAdministration.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationDispenseSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationDispenseSearchParams.kt
@@ -104,9 +104,7 @@ public object MedicationDispenseSearchParams {
       expression = "MedicationDispense.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationRequestSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationRequestSearchParams.kt
@@ -164,9 +164,7 @@ public object MedicationRequestSearchParams {
       expression = "MedicationRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationStatementSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MedicationStatementSearchParams.kt
@@ -110,9 +110,7 @@ public object MedicationStatementSearchParams {
       expression = "MedicationStatement.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MolecularSequenceSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/MolecularSequenceSearchParams.kt
@@ -372,9 +372,7 @@ public object MolecularSequenceSearchParams {
       expression = "MolecularSequence.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/NamingSystemSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/NamingSystemSearchParams.kt
@@ -430,7 +430,7 @@ public object NamingSystemSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -667,7 +667,7 @@ public object NamingSystemSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/NutritionIntakeSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/NutritionIntakeSearchParams.kt
@@ -94,9 +94,7 @@ public object NutritionIntakeSearchParams {
       expression = "NutritionIntake.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/NutritionOrderSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/NutritionOrderSearchParams.kt
@@ -106,9 +106,7 @@ public object NutritionOrderSearchParams {
       expression = "NutritionOrder.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ObservationSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ObservationSearchParams.kt
@@ -683,9 +683,7 @@ public object ObservationSearchParams {
       expression = "Observation.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/PersonSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/PersonSearchParams.kt
@@ -196,9 +196,7 @@ public object PersonSearchParams {
       expression = "Person.link.target.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        resource.link
-          .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("Patient/") == true }
+        resource.link.map { it.target }.filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 
@@ -229,7 +227,7 @@ public object PersonSearchParams {
       extractor = { resource ->
         resource.link
           .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("Practitioner/") == true }
+          .filter { it.reference?.value?.contains("Practitioner/") == true }
       },
     )
 
@@ -242,7 +240,7 @@ public object PersonSearchParams {
       extractor = { resource ->
         resource.link
           .map { it.target }
-          .filter { it.reference?.value?.toString()?.contains("RelatedPerson/") == true }
+          .filter { it.reference?.value?.contains("RelatedPerson/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/PlanDefinitionSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/PlanDefinitionSearchParams.kt
@@ -365,7 +365,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "composed-of" }
+          .filter { it.type.value?.toString() == "composed-of" }
           .mapNotNull { it.resource }
       },
     )
@@ -615,7 +615,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "depends-on" }
+          .filter { it.type.value?.toString() == "depends-on" }
           .mapNotNull { it.resource }
       },
     )
@@ -788,7 +788,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -1001,7 +1001,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )
@@ -1190,7 +1190,7 @@ public object PlanDefinitionSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "successor" }
+          .filter { it.type.value?.toString() == "successor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ProcedureSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ProcedureSearchParams.kt
@@ -162,9 +162,7 @@ public object ProcedureSearchParams {
       expression = "Procedure.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/QuestionnaireResponseSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/QuestionnaireResponseSearchParams.kt
@@ -432,9 +432,7 @@ public object QuestionnaireResponseSearchParams {
       expression = "QuestionnaireResponse.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/RequestOrchestrationSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/RequestOrchestrationSearchParams.kt
@@ -512,9 +512,7 @@ public object RequestOrchestrationSearchParams {
       expression = "RequestOrchestration.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ResearchSubjectSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ResearchSubjectSearchParams.kt
@@ -64,9 +64,7 @@ public object ResearchSubjectSearchParams {
       expression = "ResearchSubject.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/RiskAssessmentSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/RiskAssessmentSearchParams.kt
@@ -94,9 +94,7 @@ public object RiskAssessmentSearchParams {
       expression = "RiskAssessment.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/SearchParam.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/SearchParam.kt
@@ -45,5 +45,5 @@ public class SearchParam<R : Resource, T>(
  * Extracts the values for [param] from this resource. Equivalent to `param.extractFrom(this)`, but
  * reads more fluently at the call site (e.g. `patient.extract(PatientSearchParams.birthdate)`).
  */
-public inline fun <R : Resource, T> R.extract(`param`: SearchParam<R, T>): List<T> =
+public fun <R : Resource, T> R.extract(`param`: SearchParam<R, T>): List<T> =
   param.extractFrom(this)

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ServiceRequestSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ServiceRequestSearchParams.kt
@@ -173,9 +173,7 @@ public object ServiceRequestSearchParams {
       expression = "ServiceRequest.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOf(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOf(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/SpecimenSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/SpecimenSearchParams.kt
@@ -92,7 +92,7 @@ public object SpecimenSearchParams {
       extractor = { resource ->
         resource.container
           .map { it.device }
-          .filter { it.reference?.value?.toString()?.contains("Device/") == true }
+          .filter { it.reference?.value?.contains("Device/") == true }
       },
     )
 
@@ -120,9 +120,7 @@ public object SpecimenSearchParams {
       expression = "Specimen.subject.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.subject).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.subject).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/TaskSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/TaskSearchParams.kt
@@ -818,9 +818,7 @@ public object TaskSearchParams {
       expression = "Task.for.where(resolve() is Patient)",
       target = listOf(Patient::class),
       extractor = { resource ->
-        listOfNotNull(resource.`for`).filter {
-          it.reference?.value?.toString()?.contains("Patient/") == true
-        }
+        listOfNotNull(resource.`for`).filter { it.reference?.value?.contains("Patient/") == true }
       },
     )
 

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ValueSetSearchParams.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/search/ValueSetSearchParams.kt
@@ -431,7 +431,7 @@ public object ValueSetSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "derived-from" }
+          .filter { it.type.value?.toString() == "derived-from" }
           .mapNotNull { it.resource }
       },
     )
@@ -652,7 +652,7 @@ public object ValueSetSearchParams {
         ),
       extractor = { resource ->
         resource.relatedArtifact
-          .filter { it.type?.value?.toString() == "predecessor" }
+          .filter { it.type.value?.toString() == "predecessor" }
           .mapNotNull { it.resource }
       },
     )

--- a/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/terminologies/AllSecurityLabels.kt
+++ b/fhir-model-r5/src/commonMain/kotlin/dev/ohs/fhir/model/r5/terminologies/AllSecurityLabels.kt
@@ -2002,7 +2002,6 @@ public enum class AllSecurityLabels(
         "ECH" -> Ech
         "FLY" -> Fly
         "IND" -> Ind
-        "SSP" -> Ssp
         "_CoverageItemLimitObservationValue" -> _CoverageItemLimitObservationValue
         "_CoverageLocationLimitObservationValue" -> _CoverageLocationLimitObservationValue
         "_CriticalityObservationValue" -> _CriticalityObservationValue
@@ -2048,7 +2047,6 @@ public enum class AllSecurityLabels(
         "LE" -> Le
         "ME" -> Me
         "MI" -> Mi
-        "N" -> N
         "S" -> S
         "_SecurityObservationValue" -> _SecurityObservationValue
         "_SECCATOBV" -> _Seccatobv
@@ -2104,8 +2102,6 @@ public enum class AllSecurityLabels(
         "TRSTMECOBV" -> Trstmecobv
         "_SeverityObservation" -> _SeverityObservation
         "H" -> H
-        "L" -> L
-        "M" -> M
         "_SubjectBodyPosition" -> _SubjectBodyPosition
         "LLD" -> Lld
         "PRN" -> Prn

--- a/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/JsonConfigurationTest.kt
+++ b/fhir-model/src/commonTest/kotlin/dev/ohs/fhir/model/test/JsonConfigurationTest.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("RedundantJson")
+
 package dev.ohs.fhir.model.test
 
 import dev.ohs.fhir.model.r4.Patient


### PR DESCRIPTION
Here is the extremely concise summary of the core changes:

* Added `.distinctBy { it.code }` when generating `fromCode()` in `EnumTypeSpecGenerator.kt` to fix unreachable code warnings for enum sets with duplicate codes (e.g., `AllSecurityLabels`).
* Resolved field schema nullability in `SearchParamPattern.kt` to emit direct access (`.`) or safe calls (`?.`) in `SearchParamExtractFromFunctionBodyEmitter.kt`.
* Removed Redundant `.toString()` on `reference?.value` in `where(resolve() is Type)` since it is already `String?`.
* Dropped `inline` from `Resource.extract(param)` in `SearchParamFileSpecGenerator.kt` to silence compiler inline performance warnings.
* Replaced the single data class in `SearchParamPattern.kt` with a sealed hierarchy (`Resolve` vs `Filter`), eliminating all unsafe non-null assertions (`!!`).
* Added `@file:Suppress("RedundantJson")` to `JsonConfigurationTest.kt`.